### PR TITLE
Milestone B: Dialogue vertical slice with AI fallback

### DIFF
--- a/app/src/main/kotlin/com/chimera/ai/DialogueOrchestrator.kt
+++ b/app/src/main/kotlin/com/chimera/ai/DialogueOrchestrator.kt
@@ -1,0 +1,88 @@
+package com.chimera.ai
+
+import android.util.Log
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.MemoryShard
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Orchestrates dialogue turn generation with automatic fallback.
+ * Tries the primary provider first, falls back to FakeDialogueProvider on failure.
+ */
+@Singleton
+class DialogueOrchestrator @Inject constructor(
+    private val fallbackProvider: FakeDialogueProvider
+) {
+    // Primary provider will be injected when cloud AI is implemented
+    private var primaryProvider: DialogueProvider? = null
+    private var _isFallbackActive = false
+    val isFallbackActive: Boolean get() = _isFallbackActive
+
+    fun setPrimaryProvider(provider: DialogueProvider) {
+        primaryProvider = provider
+    }
+
+    suspend fun generateTurn(
+        contract: SceneContract,
+        playerInput: PlayerInput,
+        characterState: CharacterState,
+        recentMemories: List<MemoryShard> = emptyList(),
+        turnHistory: List<DialogueTurnResult> = emptyList()
+    ): DialogueTurnResult {
+        val primary = primaryProvider
+        if (primary != null) {
+            try {
+                if (primary.isAvailable()) {
+                    val result = primary.generateTurn(
+                        contract, playerInput, characterState, recentMemories, turnHistory
+                    )
+                    _isFallbackActive = false
+                    return validateAndClamp(result)
+                }
+            } catch (e: Exception) {
+                Log.w("DialogueOrchestrator", "Primary provider failed, falling back", e)
+            }
+        }
+
+        // Fallback path
+        _isFallbackActive = true
+        return validateAndClamp(
+            fallbackProvider.generateTurn(
+                contract, playerInput, characterState, recentMemories, turnHistory
+            )
+        )
+    }
+
+    suspend fun generateIntents(
+        contract: SceneContract,
+        characterState: CharacterState,
+        turnHistory: List<DialogueTurnResult> = emptyList()
+    ): List<String> {
+        val primary = primaryProvider
+        if (primary != null) {
+            try {
+                if (primary.isAvailable()) {
+                    return primary.generateIntents(contract, characterState, turnHistory)
+                }
+            } catch (e: Exception) {
+                Log.w("DialogueOrchestrator", "Primary intents failed, falling back", e)
+            }
+        }
+        return fallbackProvider.generateIntents(contract, characterState, turnHistory)
+    }
+
+    /**
+     * Validate and clamp AI output to prevent hallucinated deltas or bad flags.
+     */
+    private fun validateAndClamp(result: DialogueTurnResult): DialogueTurnResult {
+        return result.copy(
+            npcLine = result.npcLine.ifBlank { "(The NPC says nothing.)" },
+            relationshipDelta = result.relationshipDelta.coerceIn(-0.25f, 0.25f),
+            memoryCandidates = result.memoryCandidates.take(3)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/chimera/ai/DialogueProvider.kt
+++ b/app/src/main/kotlin/com/chimera/ai/DialogueProvider.kt
@@ -1,0 +1,40 @@
+package com.chimera.ai
+
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.MemoryShard
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
+
+/**
+ * Abstraction for dialogue generation. Implementations include:
+ * - FakeDialogueProvider (authored templates, deterministic)
+ * - Future: CloudDialogueProvider (AI-backed)
+ * - Future: OnDeviceDialogueProvider (local model)
+ */
+interface DialogueProvider {
+
+    /**
+     * Generate one NPC response turn given the scene context and player input.
+     * Must return a valid [DialogueTurnResult] or throw.
+     */
+    suspend fun generateTurn(
+        contract: SceneContract,
+        playerInput: PlayerInput,
+        characterState: CharacterState,
+        recentMemories: List<MemoryShard>,
+        turnHistory: List<DialogueTurnResult>
+    ): DialogueTurnResult
+
+    /**
+     * Generate quick intent options for the player based on scene context.
+     */
+    suspend fun generateIntents(
+        contract: SceneContract,
+        characterState: CharacterState,
+        turnHistory: List<DialogueTurnResult>
+    ): List<String>
+
+    /** True if the provider is available and healthy. */
+    suspend fun isAvailable(): Boolean
+}

--- a/app/src/main/kotlin/com/chimera/ai/FakeDialogueProvider.kt
+++ b/app/src/main/kotlin/com/chimera/ai/FakeDialogueProvider.kt
@@ -1,0 +1,173 @@
+package com.chimera.ai
+
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.MemoryShard
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Deterministic dialogue provider using authored templates.
+ * Used as the offline fallback and for development/testing.
+ * Returns authored NPC responses with disposition-aware branching.
+ */
+@Singleton
+class FakeDialogueProvider @Inject constructor() : DialogueProvider {
+
+    override suspend fun generateTurn(
+        contract: SceneContract,
+        playerInput: PlayerInput,
+        characterState: CharacterState,
+        recentMemories: List<MemoryShard>,
+        turnHistory: List<DialogueTurnResult>
+    ): DialogueTurnResult {
+        val disposition = characterState.dispositionToPlayer
+        val turnCount = turnHistory.size
+
+        // Select response based on disposition and input tone
+        val inputLower = playerInput.text.lowercase()
+        val isThreatening = inputLower.containsAny("threaten", "kill", "destroy", "fight", "attack")
+        val isKind = inputLower.containsAny("help", "friend", "trust", "sorry", "please", "thank")
+        val isQuestion = inputLower.contains("?") || inputLower.containsAny("why", "what", "how", "where", "who")
+
+        return when {
+            isThreatening && disposition < 0f -> DialogueTurnResult(
+                npcLine = "You dare threaten me? After everything? I should have known better than to trust an outsider.",
+                emotion = "hostile",
+                relationshipDelta = -0.15f,
+                flags = listOf("hostility_escalated"),
+                memoryCandidates = listOf("Player threatened ${contract.npcName} while relationship was already strained")
+            )
+            isThreatening && disposition >= 0f -> DialogueTurnResult(
+                npcLine = "I... didn't expect that from you. Perhaps I misjudged who you are.",
+                emotion = "hurt",
+                relationshipDelta = -0.10f,
+                flags = listOf("trust_broken"),
+                memoryCandidates = listOf("Player turned aggressive despite good standing with ${contract.npcName}")
+            )
+            isKind && disposition > 0.3f -> DialogueTurnResult(
+                npcLine = "Your words carry weight with me, more than you might know. The Hollow tests everyone, but perhaps together we can endure it.",
+                emotion = "grateful",
+                relationshipDelta = 0.08f,
+                memoryCandidates = listOf("Player showed kindness to ${contract.npcName} during the ${contract.sceneTitle}")
+            )
+            isKind && disposition <= 0.3f -> DialogueTurnResult(
+                npcLine = "Kind words are cheap in the Hollow. But... I'll remember you said that.",
+                emotion = "guarded",
+                relationshipDelta = 0.05f,
+                memoryCandidates = listOf("Player attempted to build trust with ${contract.npcName}")
+            )
+            isQuestion -> DialogueTurnResult(
+                npcLine = getQuestionResponse(contract, turnCount),
+                emotion = "thoughtful",
+                relationshipDelta = 0.02f,
+                memoryCandidates = listOf("Player asked questions about the ${contract.setting}")
+            )
+            turnCount == 0 -> DialogueTurnResult(
+                npcLine = "The path you walk is not one taken lightly. Tell me -- what brought you to the ${contract.setting}?",
+                emotion = "curious",
+                relationshipDelta = 0f,
+                directorNotes = "Opening turn, establish NPC voice"
+            )
+            turnCount >= contract.maxTurns - 1 -> DialogueTurnResult(
+                npcLine = "We've spoken long enough. The shadows grow restless, and we both have places to be. Until next time.",
+                emotion = "resolute",
+                relationshipDelta = 0f,
+                flags = listOf("scene_ending"),
+                directorNotes = "Scene reaching max turns, wrap up"
+            )
+            else -> DialogueTurnResult(
+                npcLine = getGenericResponse(disposition, turnCount),
+                emotion = if (disposition > 0.2f) "warm" else if (disposition < -0.2f) "cold" else "neutral",
+                relationshipDelta = 0.01f
+            )
+        }
+    }
+
+    override suspend fun generateIntents(
+        contract: SceneContract,
+        characterState: CharacterState,
+        turnHistory: List<DialogueTurnResult>
+    ): List<String> {
+        val disposition = characterState.dispositionToPlayer
+        val turnCount = turnHistory.size
+
+        return when {
+            turnCount == 0 -> listOf(
+                "I seek the truth about the Hollow King.",
+                "I have a debt to repay.",
+                "Curiosity, nothing more.",
+                "None of your concern."
+            )
+            turnHistory.lastOrNull()?.flags?.contains("scene_ending") == true -> listOf(
+                "Farewell, and stay safe.",
+                "We'll meet again.",
+                "[Leave silently]"
+            )
+            disposition < -0.3f -> listOf(
+                "I mean no harm.",
+                "What would it take to earn your trust?",
+                "Then we have nothing more to discuss.",
+                "You'll regret this attitude."
+            )
+            disposition > 0.3f -> listOf(
+                "Tell me more about yourself.",
+                "What dangers lie ahead?",
+                "I could use your help with something.",
+                "Thank you for trusting me."
+            )
+            else -> listOf(
+                "Tell me what you know.",
+                "What do you make of all this?",
+                "I have my own reasons.",
+                "Let's get to the point."
+            )
+        }
+    }
+
+    override suspend fun isAvailable(): Boolean = true
+
+    private fun getQuestionResponse(contract: SceneContract, turnCount: Int): String {
+        val responses = listOf(
+            "That's not a simple question. The ${contract.setting} holds many secrets, and not all of them want to be found.",
+            "You ask the right questions, at least. Most who come here never think to ask at all.",
+            "The answer depends on who you ask. The old stories say one thing. What I've seen says another.",
+            "I could tell you, but the truth has a cost in the Hollow. Are you willing to pay it?"
+        )
+        return responses[turnCount % responses.size]
+    }
+
+    private fun getGenericResponse(disposition: Float, turnCount: Int): String {
+        return when {
+            disposition > 0.5f -> {
+                val warm = listOf(
+                    "I'm glad you're here. Not many allies remain in these lands.",
+                    "You've proven yourself more than most. The Hollow hasn't broken you yet.",
+                    "There's something I should tell you -- but not here. Meet me at camp tonight."
+                )
+                warm[turnCount % warm.size]
+            }
+            disposition < -0.3f -> {
+                val cold = listOf(
+                    "Speak your piece and be done with it. My patience wears thin.",
+                    "Every word you say reminds me why I don't trust outsiders.",
+                    "The Hollow has a way of revealing who people really are. I wonder what it will reveal about you."
+                )
+                cold[turnCount % cold.size]
+            }
+            else -> {
+                val neutral = listOf(
+                    "The road ahead is uncertain. But then, it always is in the Hollow.",
+                    "I've seen things in these ruins that would turn your blood cold. Tread carefully.",
+                    "Others have come before you. Most didn't last long. What makes you different?"
+                )
+                neutral[turnCount % neutral.size]
+            }
+        }
+    }
+
+    private fun String.containsAny(vararg words: String): Boolean =
+        words.any { this.contains(it) }
+}

--- a/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneScreen.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneScreen.kt
@@ -1,8 +1,13 @@
 package com.chimera.ui.screens.dialogue
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -12,26 +17,38 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,6 +66,7 @@ fun DialogueSceneScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
+    var typedInput by remember { mutableStateOf("") }
 
     LaunchedEffect(uiState.transcript.size) {
         if (uiState.transcript.isNotEmpty()) {
@@ -73,23 +91,58 @@ fun DialogueSceneScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(onClick = onSceneComplete) {
-                    Icon(
-                        Icons.Default.ArrowBack,
-                        contentDescription = "Leave scene",
-                        tint = FadedBone
-                    )
+                    Icon(Icons.Default.ArrowBack, "Leave scene", tint = FadedBone)
                 }
                 Spacer(modifier = Modifier.width(8.dp))
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(uiState.sceneTitle, style = MaterialTheme.typography.titleMedium)
                     Text(
-                        text = uiState.sceneTitle,
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Text(
-                        text = "${uiState.npcName} - ${uiState.npcMood}",
+                        "${uiState.npcName} -- ${uiState.npcMood}",
                         style = MaterialTheme.typography.bodySmall,
                         color = FadedBone
                     )
+                }
+                if (uiState.isFallbackMode) {
+                    Text(
+                        "AUTHORED",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = EmberGold.copy(alpha = 0.6f),
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                }
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = EmberGold
+                    )
+                }
+            }
+        }
+
+        // Relationship banner
+        AnimatedVisibility(
+            visible = uiState.relationshipBanner != null,
+            enter = slideInVertically() + fadeIn(),
+            exit = fadeOut()
+        ) {
+            uiState.relationshipBanner?.let { banner ->
+                Surface(
+                    color = if (banner.delta > 0) VoidGreen.copy(alpha = 0.2f) else HollowCrimson.copy(alpha = 0.2f),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "${banner.npcName}: ${if (banner.delta > 0) "+" else ""}${String.format("%.0f", banner.delta * 100)}%",
+                        style = MaterialTheme.typography.labelMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                        color = if (banner.delta > 0) VoidGreen else HollowCrimson,
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                LaunchedEffect(banner) {
+                    kotlinx.coroutines.delay(2500)
+                    viewModel.dismissRelationshipBanner()
                 }
             }
         }
@@ -108,11 +161,8 @@ fun DialogueSceneScreen(
         }
 
         // Quick intents
-        if (uiState.quickIntents.isNotEmpty()) {
-            Surface(
-                color = MaterialTheme.colorScheme.surface,
-                shadowElevation = 4.dp
-            ) {
+        if (uiState.quickIntents.isNotEmpty() && !uiState.isLoading) {
+            Surface(color = MaterialTheme.colorScheme.surface) {
                 FlowRow(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -123,12 +173,7 @@ fun DialogueSceneScreen(
                     uiState.quickIntents.forEach { intent ->
                         AssistChip(
                             onClick = { viewModel.selectIntent(intent) },
-                            label = {
-                                Text(
-                                    text = intent,
-                                    style = MaterialTheme.typography.bodySmall
-                                )
-                            },
+                            label = { Text(intent, style = MaterialTheme.typography.bodySmall) },
                             colors = AssistChipDefaults.assistChipColors(
                                 containerColor = MaterialTheme.colorScheme.surfaceVariant,
                                 labelColor = MaterialTheme.colorScheme.onSurface
@@ -137,6 +182,46 @@ fun DialogueSceneScreen(
                                 borderColor = EmberGold.copy(alpha = 0.3f)
                             )
                         )
+                    }
+                }
+            }
+        }
+
+        // Text input composer
+        if (!uiState.isSceneComplete) {
+            val sendMessage = {
+                if (typedInput.isNotBlank()) {
+                    viewModel.submitTypedInput(typedInput)
+                    typedInput = ""
+                }
+            }
+            Surface(color = MaterialTheme.colorScheme.surface, shadowElevation = 4.dp) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = typedInput,
+                        onValueChange = { typedInput = it },
+                        modifier = Modifier.weight(1f),
+                        placeholder = { Text("Speak your mind...") },
+                        singleLine = true,
+                        enabled = !uiState.isLoading,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                        keyboardActions = KeyboardActions(onSend = { sendMessage() }),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = EmberGold,
+                            cursorColor = EmberGold
+                        )
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    IconButton(
+                        onClick = { sendMessage() },
+                        enabled = typedInput.isNotBlank() && !uiState.isLoading
+                    ) {
+                        Icon(Icons.Default.Send, "Send", tint = EmberGold)
                     }
                 }
             }
@@ -154,12 +239,22 @@ private fun DialogueBubble(line: DialogueLine) {
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = alignment
     ) {
-        Text(
-            text = line.speakerName,
-            style = MaterialTheme.typography.labelMedium,
-            color = nameColor,
-            modifier = Modifier.padding(bottom = 4.dp)
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = line.speakerName,
+                style = MaterialTheme.typography.labelMedium,
+                color = nameColor
+            )
+            if (!line.isPlayer && line.emotion != "neutral") {
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = line.emotion,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = FadedBone.copy(alpha = 0.6f)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
         Card(
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant

--- a/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
@@ -1,76 +1,286 @@
 package com.chimera.ui.screens.dialogue
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chimera.ai.DialogueOrchestrator
+import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.CharacterStateDao
+import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.MemoryShardDao
+import com.chimera.database.dao.SceneInstanceDao
+import com.chimera.database.entity.DialogueTurnEntity
+import com.chimera.database.entity.MemoryShardEntity
+import com.chimera.database.entity.SceneInstanceEntity
+import com.chimera.database.mapper.toModel
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.MemoryShard
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-data class DialogueUiState(
-    val sceneId: String = "",
-    val sceneTitle: String = "The Hollow Threshold",
-    val npcName: String = "The Warden",
-    val npcMood: String = "guarded",
-    val transcript: List<DialogueLine> = emptyList(),
-    val quickIntents: List<String> = emptyList(),
-    val isLoading: Boolean = false,
-    val isFallbackMode: Boolean = false
-)
 
 data class DialogueLine(
     val speakerId: String,
     val speakerName: String,
     val text: String,
+    val emotion: String = "neutral",
     val isPlayer: Boolean = false
 )
 
+data class DialogueUiState(
+    val sceneId: String = "",
+    val sceneTitle: String = "",
+    val npcName: String = "",
+    val npcMood: String = "neutral",
+    val transcript: List<DialogueLine> = emptyList(),
+    val quickIntents: List<String> = emptyList(),
+    val isLoading: Boolean = false,
+    val isFallbackMode: Boolean = false,
+    val isSceneComplete: Boolean = false,
+    val relationshipBanner: RelationshipBanner? = null
+)
+
+data class RelationshipBanner(
+    val npcName: String,
+    val delta: Float,
+    val newDisposition: Float
+) {
+    companion object {
+        const val SIGNIFICANCE_THRESHOLD = 0.05f
+    }
+}
+
 @HiltViewModel
 class DialogueSceneViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val orchestrator: DialogueOrchestrator,
+    private val gameSessionManager: GameSessionManager,
+    private val dialogueTurnDao: DialogueTurnDao,
+    private val sceneInstanceDao: SceneInstanceDao,
+    private val memoryShardDao: MemoryShardDao,
+    private val characterStateDao: CharacterStateDao
 ) : ViewModel() {
 
     private val sceneId: String = savedStateHandle["sceneId"] ?: ""
-
-    private val _uiState = MutableStateFlow(
-        DialogueUiState(
-            sceneId = sceneId,
-            transcript = listOf(
-                DialogueLine(
-                    speakerId = "warden",
-                    speakerName = "The Warden",
-                    text = "You stand at the threshold of the Hollow. " +
-                        "Few who enter return unchanged. What drives you forward?"
-                ),
-            ),
-            quickIntents = listOf(
-                "I seek the truth.",
-                "I have a debt to repay.",
-                "Curiosity, nothing more.",
-                "None of your concern."
-            )
-        )
-    )
+    private val _uiState = MutableStateFlow(DialogueUiState(sceneId = sceneId))
     val uiState: StateFlow<DialogueUiState> = _uiState.asStateFlow()
 
+    private val turnResults = mutableListOf<DialogueTurnResult>()
+    private var recentMemories = mutableListOf<MemoryShard>()
+    private var sceneInstanceId: Long = 0
+    private var cachedCharState: CharacterState? = null
+
+    companion object {
+        private const val MAX_TURN_HISTORY = 20
+    }
+
+    private val contract = SceneContract(
+        sceneId = sceneId,
+        sceneTitle = "The Hollow Threshold",
+        npcId = "warden",
+        npcName = "The Warden",
+        setting = "the crumbling gates of the Hollow",
+        stakes = "First contact with a gatekeeper who controls access to the ruins"
+    )
+
+    init {
+        initializeScene()
+    }
+
+    private fun initializeScene() {
+        viewModelScope.launch {
+            try {
+                val slotId = gameSessionManager.activeSlotId.value ?: return@launch
+                _uiState.value = _uiState.value.copy(
+                    sceneTitle = contract.sceneTitle,
+                    npcName = contract.npcName,
+                    isLoading = true
+                )
+
+                sceneInstanceId = sceneInstanceDao.insert(
+                    SceneInstanceEntity(
+                        saveSlotId = slotId,
+                        sceneId = sceneId,
+                        npcId = contract.npcId
+                    )
+                )
+
+                val charState = loadCharacterState(slotId)
+                recentMemories = memoryShardDao.getTopMemories(slotId, contract.npcId, 5)
+                    .map { it.toModel() }
+                    .toMutableList()
+
+                val openingInput = PlayerInput(text = "[Scene begins]", isQuickIntent = true)
+                val result = orchestrator.generateTurn(
+                    contract, openingInput, charState, recentMemories, turnResults
+                )
+                turnResults.add(result)
+
+                persistTurn(contract.npcId, result.npcLine, result.emotion)
+
+                val intents = orchestrator.generateIntents(contract, charState, turnResults)
+
+                _uiState.value = _uiState.value.copy(
+                    transcript = listOf(
+                        DialogueLine(
+                            speakerId = contract.npcId,
+                            speakerName = contract.npcName,
+                            text = result.npcLine,
+                            emotion = result.emotion
+                        )
+                    ),
+                    npcMood = result.emotion,
+                    quickIntents = intents,
+                    isFallbackMode = orchestrator.isFallbackActive,
+                    isLoading = false
+                )
+            } catch (e: Exception) {
+                Log.e("DialogueVM", "Failed to initialize scene", e)
+                _uiState.value = _uiState.value.copy(isLoading = false)
+            }
+        }
+    }
+
     fun selectIntent(intent: String) {
-        val current = _uiState.value
-        val playerLine = DialogueLine(
-            speakerId = "player",
-            speakerName = "You",
-            text = intent,
-            isPlayer = true
-        )
-        val npcResponse = DialogueLine(
-            speakerId = "warden",
-            speakerName = "The Warden",
-            text = "Interesting. The Hollow will test that resolve. " +
-                "Step carefully -- the shadows remember every word spoken here."
-        )
-        _uiState.value = current.copy(
-            transcript = current.transcript + playerLine + npcResponse,
-            quickIntents = emptyList()
+        submitPlayerInput(PlayerInput(text = intent, isQuickIntent = true))
+    }
+
+    fun submitTypedInput(text: String) {
+        if (text.isBlank()) return
+        submitPlayerInput(PlayerInput(text = text.trim()))
+    }
+
+    private fun submitPlayerInput(input: PlayerInput) {
+        if (_uiState.value.isLoading || _uiState.value.isSceneComplete) return
+
+        viewModelScope.launch {
+            try {
+                val slotId = gameSessionManager.activeSlotId.value ?: return@launch
+                _uiState.value = _uiState.value.copy(isLoading = true, quickIntents = emptyList())
+
+                val playerLine = DialogueLine(
+                    speakerId = "player",
+                    speakerName = "You",
+                    text = input.text,
+                    isPlayer = true
+                )
+                persistTurn("player", input.text, "")
+
+                val charState = loadCharacterState(slotId)
+
+                val result = orchestrator.generateTurn(
+                    contract, input, charState, recentMemories, turnResults
+                )
+                addTurnResult(result)
+
+                persistTurn(contract.npcId, result.npcLine, result.emotion)
+
+                // Batch insert memory candidates
+                if (result.memoryCandidates.isNotEmpty()) {
+                    val shards = result.memoryCandidates.map { summary ->
+                        MemoryShardEntity(
+                            saveSlotId = slotId,
+                            sceneId = sceneId,
+                            characterId = contract.npcId,
+                            summary = summary,
+                            importanceScore = 0.6f
+                        )
+                    }
+                    memoryShardDao.insertAll(shards)
+                    recentMemories.addAll(shards.map { it.toModel() })
+                }
+
+                if (result.relationshipDelta != 0f) {
+                    characterStateDao.adjustDisposition(contract.npcId, result.relationshipDelta)
+                    cachedCharState = null // invalidate cache after mutation
+                }
+
+                val npcLine = DialogueLine(
+                    speakerId = contract.npcId,
+                    speakerName = contract.npcName,
+                    text = result.npcLine,
+                    emotion = result.emotion
+                )
+
+                val isEnding = result.flags.contains("scene_ending") ||
+                    turnResults.size >= contract.maxTurns
+
+                val intents = if (isEnding) {
+                    listOf("Farewell.", "[Leave]")
+                } else {
+                    orchestrator.generateIntents(contract, charState, turnResults)
+                }
+
+                val banner = if (kotlin.math.abs(result.relationshipDelta) >= RelationshipBanner.SIGNIFICANCE_THRESHOLD) {
+                    val updated = loadCharacterState(slotId)
+                    RelationshipBanner(
+                        npcName = contract.npcName,
+                        delta = result.relationshipDelta,
+                        newDisposition = updated.dispositionToPlayer
+                    )
+                } else null
+
+                _uiState.value = _uiState.value.copy(
+                    transcript = _uiState.value.transcript + playerLine + npcLine,
+                    npcMood = result.emotion,
+                    quickIntents = intents,
+                    isFallbackMode = orchestrator.isFallbackActive,
+                    isSceneComplete = isEnding,
+                    relationshipBanner = banner,
+                    isLoading = false
+                )
+
+                if (isEnding) {
+                    sceneInstanceDao.completeScene(
+                        id = sceneInstanceId,
+                        turnCount = turnResults.size,
+                        usedFallback = orchestrator.isFallbackActive
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("DialogueVM", "Failed to process turn", e)
+                _uiState.value = _uiState.value.copy(isLoading = false)
+            }
+        }
+    }
+
+    fun dismissRelationshipBanner() {
+        _uiState.value = _uiState.value.copy(relationshipBanner = null)
+    }
+
+    private suspend fun loadCharacterState(slotId: Long): CharacterState {
+        cachedCharState?.let { return it }
+        val state = characterStateDao.getByCharacterId(contract.npcId)?.toModel()
+            ?: CharacterState(characterId = contract.npcId, saveSlotId = slotId)
+        cachedCharState = state
+        return state
+    }
+
+    private fun addTurnResult(result: DialogueTurnResult) {
+        turnResults.add(result)
+        // Keep only recent history to bound memory
+        if (turnResults.size > MAX_TURN_HISTORY) {
+            turnResults.removeAt(0)
+        }
+    }
+
+    private suspend fun persistTurn(speakerId: String, text: String, emotion: String) {
+        val slotId = gameSessionManager.activeSlotId.value ?: return
+        dialogueTurnDao.insert(
+            DialogueTurnEntity(
+                saveSlotId = slotId,
+                sceneId = sceneId,
+                speakerId = speakerId,
+                lineText = text,
+                emotionJson = "{\"primary\":\"$emotion\"}"
+            )
         )
     }
 }

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -10,23 +10,26 @@ import com.chimera.database.converter.Converters
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.MemoryShardDao
 import com.chimera.database.dao.SaveSlotDao
+import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.entity.CharacterEntity
 import com.chimera.database.entity.CharacterStateEntity
 import com.chimera.database.entity.DialogueTurnEntity
+import com.chimera.database.entity.MemoryShardEntity
 import com.chimera.database.entity.SaveSlotEntity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import com.chimera.database.entity.SceneInstanceEntity
 
 @Database(
     entities = [
         SaveSlotEntity::class,
         CharacterEntity::class,
         CharacterStateEntity::class,
-        DialogueTurnEntity::class
+        DialogueTurnEntity::class,
+        MemoryShardEntity::class,
+        SceneInstanceEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -36,6 +39,8 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     abstract fun characterDao(): CharacterDao
     abstract fun characterStateDao(): CharacterStateDao
     abstract fun dialogueTurnDao(): DialogueTurnDao
+    abstract fun memoryShardDao(): MemoryShardDao
+    abstract fun sceneInstanceDao(): SceneInstanceDao
 
     companion object {
         const val DATABASE_NAME = "chimera_game.db"
@@ -55,13 +60,13 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     private class PrepopulateCallback : Callback() {
         override fun onCreate(db: SupportSQLiteDatabase) {
             super.onCreate(db)
-            // Insert 3 empty save slots on first database creation
+            val now = System.currentTimeMillis()
             for (index in 0..2) {
                 db.execSQL(
                     "INSERT INTO save_slots (slot_index, player_name, chapter_tag, " +
                     "playtime_seconds, last_played_at, created_at, is_empty) " +
-                    "VALUES ($index, '', 'prologue', 0, ${System.currentTimeMillis()}, " +
-                    "${System.currentTimeMillis()}, 1)"
+                    "VALUES (?, '', 'prologue', 0, ?, ?, 1)",
+                    arrayOf(index, now, now)
                 )
             }
         }

--- a/core-database/src/main/kotlin/com/chimera/database/dao/MemoryShardDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/MemoryShardDao.kt
@@ -1,0 +1,34 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.chimera.database.entity.MemoryShardEntity
+
+@Dao
+interface MemoryShardDao {
+
+    @Insert
+    suspend fun insert(shard: MemoryShardEntity): Long
+
+    @Insert
+    suspend fun insertAll(shards: List<MemoryShardEntity>)
+
+    @Query(
+        "SELECT * FROM memory_shards " +
+        "WHERE save_slot_id = :slotId AND character_id = :characterId " +
+        "ORDER BY importance_score DESC, created_at DESC " +
+        "LIMIT :limit"
+    )
+    suspend fun getTopMemories(slotId: Long, characterId: String, limit: Int = 10): List<MemoryShardEntity>
+
+    @Query(
+        "SELECT * FROM memory_shards " +
+        "WHERE save_slot_id = :slotId AND scene_id = :sceneId " +
+        "ORDER BY created_at ASC"
+    )
+    suspend fun getByScene(slotId: Long, sceneId: String): List<MemoryShardEntity>
+
+    @Query("SELECT COUNT(*) FROM memory_shards WHERE save_slot_id = :slotId")
+    suspend fun countBySlot(slotId: Long): Int
+}

--- a/core-database/src/main/kotlin/com/chimera/database/dao/SceneInstanceDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/SceneInstanceDao.kt
@@ -1,0 +1,37 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.chimera.database.entity.SceneInstanceEntity
+
+@Dao
+interface SceneInstanceDao {
+
+    @Insert
+    suspend fun insert(scene: SceneInstanceEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(scene: SceneInstanceEntity)
+
+    @Query("SELECT * FROM scene_instances WHERE id = :id")
+    suspend fun getById(id: Long): SceneInstanceEntity?
+
+    @Query(
+        "SELECT * FROM scene_instances " +
+        "WHERE save_slot_id = :slotId AND scene_id = :sceneId AND status = 'active' " +
+        "LIMIT 1"
+    )
+    suspend fun getActiveScene(slotId: Long, sceneId: String): SceneInstanceEntity?
+
+    @Query(
+        "UPDATE scene_instances SET status = 'completed', " +
+        "completed_at = :completedAt, turn_count = :turnCount, used_fallback = :usedFallback " +
+        "WHERE id = :id"
+    )
+    suspend fun completeScene(id: Long, turnCount: Int, usedFallback: Boolean, completedAt: Long = System.currentTimeMillis())
+
+    @Query("SELECT * FROM scene_instances WHERE save_slot_id = :slotId ORDER BY started_at DESC")
+    suspend fun getBySlot(slotId: Long): List<SceneInstanceEntity>
+}

--- a/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
@@ -5,7 +5,9 @@ import com.chimera.database.ChimeraGameDatabase
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.MemoryShardDao
 import com.chimera.database.dao.SaveSlotDao
+import com.chimera.database.dao.SceneInstanceDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,4 +36,10 @@ object DatabaseModule {
 
     @Provides
     fun provideDialogueTurnDao(db: ChimeraGameDatabase): DialogueTurnDao = db.dialogueTurnDao()
+
+    @Provides
+    fun provideMemoryShardDao(db: ChimeraGameDatabase): MemoryShardDao = db.memoryShardDao()
+
+    @Provides
+    fun provideSceneInstanceDao(db: ChimeraGameDatabase): SceneInstanceDao = db.sceneInstanceDao()
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/MemoryShardEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/MemoryShardEntity.kt
@@ -1,0 +1,48 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "memory_shards",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("save_slot_id"),
+        Index("character_id"),
+        Index("scene_id")
+    ]
+)
+data class MemoryShardEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    @ColumnInfo(name = "scene_id")
+    val sceneId: String,
+
+    @ColumnInfo(name = "character_id")
+    val characterId: String,
+
+    val summary: String,
+
+    @ColumnInfo(name = "tags_json")
+    val tagsJson: String = "[]",
+
+    @ColumnInfo(name = "importance_score")
+    val importanceScore: Float = 0.5f,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/core-database/src/main/kotlin/com/chimera/database/entity/SceneInstanceEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/SceneInstanceEntity.kt
@@ -1,0 +1,47 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "scene_instances",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id"), Index("scene_id")]
+)
+data class SceneInstanceEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    @ColumnInfo(name = "scene_id")
+    val sceneId: String,
+
+    @ColumnInfo(name = "npc_id")
+    val npcId: String,
+
+    val status: String = "active",  // active, completed, abandoned
+
+    @ColumnInfo(name = "turn_count")
+    val turnCount: Int = 0,
+
+    @ColumnInfo(name = "used_fallback")
+    val usedFallback: Boolean = false,
+
+    @ColumnInfo(name = "started_at")
+    val startedAt: Long = System.currentTimeMillis(),
+
+    @ColumnInfo(name = "completed_at")
+    val completedAt: Long? = null
+)

--- a/core-database/src/main/kotlin/com/chimera/database/mapper/EntityMappers.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/mapper/EntityMappers.kt
@@ -3,10 +3,12 @@ package com.chimera.database.mapper
 import com.chimera.database.converter.Converters
 import com.chimera.database.entity.CharacterEntity
 import com.chimera.database.entity.CharacterStateEntity
+import com.chimera.database.entity.MemoryShardEntity
 import com.chimera.database.entity.SaveSlotEntity
 import com.chimera.model.Character
 import com.chimera.model.CharacterRole
 import com.chimera.model.CharacterState
+import com.chimera.model.MemoryShard
 import com.chimera.model.SaveSlot
 
 private val converters = Converters()
@@ -75,4 +77,25 @@ fun CharacterState.toEntity() = CharacterStateEntity(
     activeArchetype = activeArchetype,
     archetypeVariablesJson = converters.fromFloatMap(archetypeVariables),
     lastInteractionEpoch = lastInteractionEpoch
+)
+
+fun MemoryShardEntity.toModel() = MemoryShard(
+    id = id,
+    saveSlotId = saveSlotId,
+    sceneId = sceneId,
+    characterId = characterId,
+    summary = summary,
+    tags = emptyList(), // TODO: add string list converter when needed
+    importanceScore = importanceScore,
+    createdAt = createdAt
+)
+
+fun MemoryShard.toEntity() = MemoryShardEntity(
+    id = id,
+    saveSlotId = saveSlotId,
+    sceneId = sceneId,
+    characterId = characterId,
+    summary = summary,
+    importanceScore = importanceScore,
+    createdAt = createdAt
 )

--- a/core-model/src/main/kotlin/com/chimera/model/Dialogue.kt
+++ b/core-model/src/main/kotlin/com/chimera/model/Dialogue.kt
@@ -1,0 +1,57 @@
+package com.chimera.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Contract for a single NPC dialogue turn produced by any provider (AI or fallback).
+ */
+@Serializable
+data class DialogueTurnResult(
+    val npcLine: String,
+    val emotion: String = "neutral",
+    val relationshipDelta: Float = 0f,
+    val flags: List<String> = emptyList(),
+    val memoryCandidates: List<String> = emptyList(),
+    val directorNotes: String = ""
+)
+
+/**
+ * Scene contract that constrains what the AI provider can generate.
+ */
+@Serializable
+data class SceneContract(
+    val sceneId: String,
+    val sceneTitle: String,
+    val npcId: String,
+    val npcName: String,
+    val setting: String = "",
+    val stakes: String = "",
+    val allowedReveals: List<String> = emptyList(),
+    val forbiddenTopics: List<String> = emptyList(),
+    val maxTurns: Int = 12
+)
+
+/**
+ * Player input for a dialogue turn, combining typed text or selected intent.
+ */
+@Serializable
+data class PlayerInput(
+    val text: String,
+    val isQuickIntent: Boolean = false,
+    val intentIndex: Int = -1
+)
+
+/**
+ * Memory shard: a compact canonical summary of a dialogue moment.
+ */
+@Serializable
+data class MemoryShard(
+    val id: Long = 0,
+    val saveSlotId: Long,
+    val sceneId: String,
+    val characterId: String,
+    val summary: String,
+    val tags: List<String> = emptyList(),
+    val importanceScore: Float = 0.5f,
+    val createdAt: Long = System.currentTimeMillis()
+)


### PR DESCRIPTION
## Summary

- **DialogueProvider** interface for pluggable AI/fallback backends
- **FakeDialogueProvider** with disposition-aware authored templates and keyword tone detection
- **DialogueOrchestrator** with automatic fallback, output validation (clamp deltas, bound memory candidates)
- **Full dialogue ViewModel**: scene lifecycle, turn persistence, cached CharacterState, bounded turn history, relationship banners
- **Text input composer** with keyboard send and quick intent chips
- **MemoryShard + SceneInstance entities** (DB v2) with batch inserts and top-N importance queries
- **Code quality** via /simplify: extracted lambdas, batch DB ops, cached state, bounded lists

## Test plan

- [ ] Enter dialogue scene from Home screen
- [ ] Opening NPC line renders with emotion indicator
- [ ] Quick intent chips appear and are tappable
- [ ] After selecting intent, player line + NPC response appear in transcript
- [ ] Type custom input and send via keyboard or button
- [ ] Relationship banner appears on significant disposition changes
- [ ] Scene completes after max turns with farewell intents
- [ ] Dialogue turns persist in database across app restart
- [ ] Memory shards created for memorable interactions

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb