### PR TITLE
Milestone C: Journal, vow system, and camp screen

### DIFF
--- a/app/src/main/kotlin/com/chimera/ui/screens/camp/CampScreen.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/camp/CampScreen.kt
@@ -1,49 +1,232 @@
 package com.chimera.ui.screens.camp
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Castle
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chimera.ui.theme.DimAsh
+import com.chimera.ui.theme.EmberGold
 import com.chimera.ui.theme.FadedBone
+import com.chimera.ui.theme.HollowCrimson
+import com.chimera.ui.theme.VoidGreen
 
 @Composable
-fun CampScreen() {
-    Column(
+fun CampScreen(
+    viewModel: CampViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Icon(
-            imageVector = Icons.Default.Castle,
-            contentDescription = null,
-            tint = DimAsh,
-            modifier = Modifier.height(64.dp)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Camp",
-            style = MaterialTheme.typography.headlineMedium,
-            color = FadedBone
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Your camp awaits.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = DimAsh
-        )
+        // Header
+        item {
+            Column(modifier = Modifier.padding(top = 16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        "Camp",
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = EmberGold
+                    )
+                    Text(
+                        "Day ${uiState.day}",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = FadedBone
+                    )
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Morale bar
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text("Camp Morale", style = MaterialTheme.typography.titleSmall)
+                            Text(
+                                "${(uiState.morale * 100).toInt()}%",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = moraleColor(uiState.morale)
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                        LinearProgressIndicator(
+                            progress = uiState.morale,
+                            modifier = Modifier.fillMaxWidth(),
+                            color = moraleColor(uiState.morale),
+                            trackColor = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+
+        // Companions section
+        item {
+            Text(
+                "Companions",
+                style = MaterialTheme.typography.titleMedium,
+                color = EmberGold,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+
+        if (uiState.companions.isEmpty()) {
+            item {
+                Text(
+                    "No companions have joined your camp yet.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = DimAsh,
+                    modifier = Modifier.padding(16.dp),
+                    textAlign = TextAlign.Center
+                )
+            }
+        } else {
+            items(uiState.companions, key = { it.character.id }) { companion ->
+                CompanionCard(data = companion)
+            }
+        }
+
+        // Active vows section
+        if (uiState.activeVows.isNotEmpty()) {
+            item {
+                Text(
+                    "Unresolved Vows",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = HollowCrimson,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+            items(uiState.activeVows, key = { it.id }) { vow ->
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                    border = BorderStroke(1.dp, HollowCrimson.copy(alpha = 0.3f))
+                ) {
+                    Text(
+                        text = vow.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(12.dp)
+                    )
+                }
+            }
+        }
+
+        // Bottom spacer for nav bar
+        item { Spacer(modifier = Modifier.height(16.dp)) }
     }
+}
+
+@Composable
+private fun CompanionCard(data: CompanionCardData) {
+    val disposition = data.state?.dispositionToPlayer ?: 0f
+    val moodLabel = when {
+        disposition > 0.5f -> "Loyal"
+        disposition > 0.2f -> "Friendly"
+        disposition > -0.2f -> "Neutral"
+        disposition > -0.5f -> "Wary"
+        else -> "Hostile"
+    }
+    val moodColor = when {
+        disposition > 0.2f -> VoidGreen
+        disposition > -0.2f -> FadedBone
+        else -> HollowCrimson
+    }
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        border = BorderStroke(1.dp, moodColor.copy(alpha = 0.3f))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Avatar
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.size(48.dp)
+            ) {
+                Text(
+                    text = data.character.name.first().toString(),
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(top = 8.dp),
+                    textAlign = TextAlign.Center,
+                    color = EmberGold
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(data.character.name, style = MaterialTheme.typography.titleSmall)
+                if (data.character.title != null) {
+                    Text(
+                        data.character.title!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = FadedBone
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(moodLabel, style = MaterialTheme.typography.labelMedium, color = moodColor)
+                    Text(
+                        "${((disposition + 1f) / 2f * 100).toInt()}%",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = FadedBone
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                LinearProgressIndicator(
+                    progress = ((disposition + 1f) / 2f).coerceIn(0f, 1f),
+                    modifier = Modifier.fillMaxWidth(),
+                    color = moodColor,
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private fun moraleColor(morale: Float) = when {
+    morale > 0.6f -> VoidGreen
+    morale > 0.3f -> EmberGold
+    else -> HollowCrimson
 }

--- a/app/src/main/kotlin/com/chimera/ui/screens/camp/CampViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/camp/CampViewModel.kt
@@ -1,0 +1,73 @@
+package com.chimera.ui.screens.camp
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterStateDao
+import com.chimera.database.dao.VowDao
+import com.chimera.database.entity.CharacterEntity
+import com.chimera.database.entity.CharacterStateEntity
+import com.chimera.database.entity.VowEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+data class CompanionCardData(
+    val character: CharacterEntity,
+    val state: CharacterStateEntity?
+)
+
+data class CampUiState(
+    val day: Int = 1,
+    val morale: Float = 0.5f,
+    val companions: List<CompanionCardData> = emptyList(),
+    val activeVows: List<VowEntity> = emptyList(),
+    val isLoading: Boolean = true
+)
+
+@HiltViewModel
+class CampViewModel @Inject constructor(
+    private val characterDao: CharacterDao,
+    private val characterStateDao: CharacterStateDao,
+    private val vowDao: VowDao,
+    gameSessionManager: GameSessionManager
+) : ViewModel() {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<CampUiState> = gameSessionManager.activeSlotId
+        .flatMapLatest { slotId ->
+            if (slotId == null) return@flatMapLatest flowOf(CampUiState(isLoading = false))
+            combine(
+                characterDao.observeCompanions(slotId),
+                characterStateDao.observeBySlot(slotId),
+                vowDao.observeActive(slotId)
+            ) { companions, states, vows ->
+                val stateMap = states.associateBy { it.characterId }
+                val companionCards = companions.map { char ->
+                    CompanionCardData(char, stateMap[char.id])
+                }
+                val avgDisposition = states
+                    .filter { it.characterId != "player" }
+                    .map { it.dispositionToPlayer }
+                    .takeIf { it.isNotEmpty() }
+                    ?.average()?.toFloat() ?: 0.5f
+                val morale = ((avgDisposition + 1f) / 2f).coerceIn(0f, 1f)
+
+                CampUiState(
+                    day = 1, // TODO: derive from scene count
+                    morale = morale,
+                    companions = companionCards,
+                    activeVows = vows,
+                    isLoading = false
+                )
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), CampUiState())
+}

--- a/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
@@ -8,9 +8,11 @@ import com.chimera.ai.DialogueOrchestrator
 import com.chimera.data.GameSessionManager
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
 import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.entity.DialogueTurnEntity
+import com.chimera.database.entity.JournalEntryEntity
 import com.chimera.database.entity.MemoryShardEntity
 import com.chimera.database.entity.SceneInstanceEntity
 import com.chimera.database.mapper.toModel
@@ -65,7 +67,8 @@ class DialogueSceneViewModel @Inject constructor(
     private val dialogueTurnDao: DialogueTurnDao,
     private val sceneInstanceDao: SceneInstanceDao,
     private val memoryShardDao: MemoryShardDao,
-    private val characterStateDao: CharacterStateDao
+    private val characterStateDao: CharacterStateDao,
+    private val journalEntryDao: JournalEntryDao
 ) : ViewModel() {
 
     private val sceneId: String = savedStateHandle["sceneId"] ?: ""
@@ -243,6 +246,7 @@ class DialogueSceneViewModel @Inject constructor(
                         turnCount = turnResults.size,
                         usedFallback = orchestrator.isFallbackActive
                     )
+                    generateJournalEntry(slotId)
                 }
             } catch (e: Exception) {
                 Log.e("DialogueVM", "Failed to process turn", e)
@@ -269,6 +273,26 @@ class DialogueSceneViewModel @Inject constructor(
         if (turnResults.size > MAX_TURN_HISTORY) {
             turnResults.removeAt(0)
         }
+    }
+
+    private suspend fun generateJournalEntry(slotId: Long) {
+        val npcLines = _uiState.value.transcript.filter { !it.isPlayer }
+        val summary = if (npcLines.size > 1) {
+            "Spoke with ${contract.npcName} at ${contract.setting}. " +
+            "The conversation spanned ${turnResults.size} exchanges."
+        } else {
+            "A brief encounter with ${contract.npcName}."
+        }
+        journalEntryDao.insert(
+            JournalEntryEntity(
+                saveSlotId = slotId,
+                title = contract.sceneTitle,
+                body = summary,
+                category = "story",
+                sceneId = sceneId,
+                characterId = contract.npcId
+            )
+        )
     }
 
     private suspend fun persistTurn(speakerId: String, text: String, emotion: String) {

--- a/app/src/main/kotlin/com/chimera/ui/screens/journal/JournalScreen.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/journal/JournalScreen.kt
@@ -1,49 +1,254 @@
 package com.chimera.ui.screens.journal
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MenuBook
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chimera.database.entity.JournalEntryEntity
+import com.chimera.database.entity.VowEntity
 import com.chimera.ui.theme.DimAsh
+import com.chimera.ui.theme.EmberGold
 import com.chimera.ui.theme.FadedBone
+import com.chimera.ui.theme.HollowCrimson
+import com.chimera.ui.theme.VoidGreen
 
 @Composable
-fun JournalScreen() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            imageVector = Icons.Default.MenuBook,
-            contentDescription = null,
-            tint = DimAsh,
-            modifier = Modifier.height(64.dp)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+fun JournalScreen(
+    viewModel: JournalViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Header
         Text(
             text = "Journal",
             style = MaterialTheme.typography.headlineMedium,
-            color = FadedBone
+            color = EmberGold,
+            modifier = Modifier.padding(start = 24.dp, top = 16.dp, bottom = 8.dp)
         )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Your journal entries will appear here.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = DimAsh
-        )
+
+        // Tabs
+        ScrollableTabRow(
+            selectedTabIndex = JournalTab.values().indexOf(uiState.selectedTab),
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = EmberGold,
+            edgePadding = 16.dp
+        ) {
+            JournalTab.values().forEach { tab ->
+                Tab(
+                    selected = uiState.selectedTab == tab,
+                    onClick = { viewModel.selectTab(tab) },
+                    text = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(tab.label, style = MaterialTheme.typography.labelLarge)
+                            if (tab == JournalTab.ALL && uiState.unreadCount > 0) {
+                                Badge(
+                                    containerColor = HollowCrimson,
+                                    modifier = Modifier.padding(start = 6.dp)
+                                ) {
+                                    Text("${uiState.unreadCount}")
+                                }
+                            }
+                        }
+                    },
+                    selectedContentColor = EmberGold,
+                    unselectedContentColor = FadedBone
+                )
+            }
+        }
+
+        // Content
+        if (uiState.selectedTab == JournalTab.VOWS) {
+            VowList(vows = uiState.vows)
+        } else {
+            EntryList(
+                entries = uiState.entries,
+                onEntryClick = { viewModel.markRead(it.id) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun EntryList(
+    entries: List<JournalEntryEntity>,
+    onEntryClick: (JournalEntryEntity) -> Unit
+) {
+    if (entries.isEmpty()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                "No entries yet.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = DimAsh
+            )
+            Text(
+                "Your deeds will be recorded here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = DimAsh
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(entries, key = { it.id }) { entry ->
+            JournalEntryCard(entry = entry, onClick = { onEntryClick(entry) })
+        }
+    }
+}
+
+@Composable
+private fun JournalEntryCard(
+    entry: JournalEntryEntity,
+    onClick: () -> Unit
+) {
+    val borderColor = when (entry.category) {
+        "story" -> EmberGold.copy(alpha = 0.4f)
+        "rumor" -> VoidGreen.copy(alpha = 0.4f)
+        "companion" -> HollowCrimson.copy(alpha = 0.4f)
+        else -> FadedBone.copy(alpha = 0.2f)
+    }
+    val categoryLabel = entry.category.replaceFirstChar { it.uppercase() }
+
+    Card(
+        onClick = onClick,
+        colors = CardDefaults.cardColors(
+            containerColor = if (entry.isRead) {
+                MaterialTheme.colorScheme.surface
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            }
+        ),
+        border = BorderStroke(1.dp, borderColor)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = entry.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (entry.isRead) FadedBone else MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = categoryLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = borderColor
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = entry.body,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+                color = FadedBone
+            )
+        }
+    }
+}
+
+@Composable
+private fun VowList(vows: List<VowEntity>) {
+    if (vows.isEmpty()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text("No vows sworn.", style = MaterialTheme.typography.bodyLarge, color = DimAsh)
+            Text(
+                "Your promises will bind you here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = DimAsh
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(vows, key = { it.id }) { vow ->
+            VowCard(vow = vow)
+        }
+    }
+}
+
+@Composable
+private fun VowCard(vow: VowEntity) {
+    val statusColor = when (vow.status) {
+        "active" -> EmberGold
+        "fulfilled" -> VoidGreen
+        "broken" -> HollowCrimson
+        else -> FadedBone
+    }
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        border = BorderStroke(1.dp, statusColor.copy(alpha = 0.4f))
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = vow.description,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = vow.status.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = statusColor
+                )
+            }
+            if (vow.swornTo != null) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Sworn to: ${vow.swornTo}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = FadedBone
+                )
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/chimera/ui/screens/journal/JournalViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/journal/JournalViewModel.kt
@@ -1,0 +1,81 @@
+package com.chimera.ui.screens.journal
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.JournalEntryDao
+import com.chimera.database.dao.VowDao
+import com.chimera.database.entity.JournalEntryEntity
+import com.chimera.database.entity.VowEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class JournalTab(val label: String, val category: String?) {
+    ALL("All", null),
+    STORY("Story", "story"),
+    RUMORS("Rumors", "rumor"),
+    VOWS("Vows", null),
+    COMPANIONS("Companions", "companion")
+}
+
+data class JournalUiState(
+    val selectedTab: JournalTab = JournalTab.ALL,
+    val entries: List<JournalEntryEntity> = emptyList(),
+    val vows: List<VowEntity> = emptyList(),
+    val unreadCount: Int = 0
+)
+
+@HiltViewModel
+class JournalViewModel @Inject constructor(
+    private val journalEntryDao: JournalEntryDao,
+    private val vowDao: VowDao,
+    private val gameSessionManager: GameSessionManager
+) : ViewModel() {
+
+    private val _selectedTab = MutableStateFlow(JournalTab.ALL)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<JournalUiState> = gameSessionManager.activeSlotId
+        .flatMapLatest { slotId ->
+            if (slotId == null) return@flatMapLatest flowOf(JournalUiState())
+            combine(
+                _selectedTab,
+                journalEntryDao.observeAll(slotId),
+                vowDao.observeAll(slotId),
+                journalEntryDao.observeUnreadCount(slotId)
+            ) { tab, allEntries, vows, unread ->
+                val filtered = when {
+                    tab == JournalTab.ALL -> allEntries
+                    tab == JournalTab.VOWS -> emptyList()
+                    tab.category != null -> allEntries.filter { it.category == tab.category }
+                    else -> allEntries
+                }
+                JournalUiState(
+                    selectedTab = tab,
+                    entries = filtered,
+                    vows = vows,
+                    unreadCount = unread
+                )
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), JournalUiState())
+
+    fun selectTab(tab: JournalTab) {
+        _selectedTab.value = tab
+    }
+
+    fun markRead(entryId: Long) {
+        viewModelScope.launch {
+            journalEntryDao.markRead(entryId)
+        }
+    }
+}

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -10,15 +10,19 @@ import com.chimera.database.converter.Converters
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
+import com.chimera.database.dao.VowDao
 import com.chimera.database.entity.CharacterEntity
 import com.chimera.database.entity.CharacterStateEntity
 import com.chimera.database.entity.DialogueTurnEntity
+import com.chimera.database.entity.JournalEntryEntity
 import com.chimera.database.entity.MemoryShardEntity
 import com.chimera.database.entity.SaveSlotEntity
 import com.chimera.database.entity.SceneInstanceEntity
+import com.chimera.database.entity.VowEntity
 
 @Database(
     entities = [
@@ -27,9 +31,11 @@ import com.chimera.database.entity.SceneInstanceEntity
         CharacterStateEntity::class,
         DialogueTurnEntity::class,
         MemoryShardEntity::class,
-        SceneInstanceEntity::class
+        SceneInstanceEntity::class,
+        JournalEntryEntity::class,
+        VowEntity::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -41,6 +47,8 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     abstract fun dialogueTurnDao(): DialogueTurnDao
     abstract fun memoryShardDao(): MemoryShardDao
     abstract fun sceneInstanceDao(): SceneInstanceDao
+    abstract fun journalEntryDao(): JournalEntryDao
+    abstract fun vowDao(): VowDao
 
     companion object {
         const val DATABASE_NAME = "chimera_game.db"

--- a/core-database/src/main/kotlin/com/chimera/database/dao/JournalEntryDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/JournalEntryDao.kt
@@ -1,0 +1,26 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.chimera.database.entity.JournalEntryEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface JournalEntryDao {
+
+    @Query("SELECT * FROM journal_entries WHERE save_slot_id = :slotId ORDER BY created_at DESC")
+    fun observeAll(slotId: Long): Flow<List<JournalEntryEntity>>
+
+    @Query("SELECT * FROM journal_entries WHERE save_slot_id = :slotId AND category = :category ORDER BY created_at DESC")
+    fun observeByCategory(slotId: Long, category: String): Flow<List<JournalEntryEntity>>
+
+    @Insert
+    suspend fun insert(entry: JournalEntryEntity): Long
+
+    @Query("UPDATE journal_entries SET is_read = 1 WHERE id = :id")
+    suspend fun markRead(id: Long)
+
+    @Query("SELECT COUNT(*) FROM journal_entries WHERE save_slot_id = :slotId AND is_read = 0")
+    fun observeUnreadCount(slotId: Long): Flow<Int>
+}

--- a/core-database/src/main/kotlin/com/chimera/database/dao/VowDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/VowDao.kt
@@ -1,0 +1,26 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.chimera.database.entity.VowEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface VowDao {
+
+    @Query("SELECT * FROM vows WHERE save_slot_id = :slotId ORDER BY created_at DESC")
+    fun observeAll(slotId: Long): Flow<List<VowEntity>>
+
+    @Query("SELECT * FROM vows WHERE save_slot_id = :slotId AND status = 'active' ORDER BY created_at DESC")
+    fun observeActive(slotId: Long): Flow<List<VowEntity>>
+
+    @Insert
+    suspend fun insert(vow: VowEntity): Long
+
+    @Query("UPDATE vows SET status = :status, resolved_at = :resolvedAt WHERE id = :id")
+    suspend fun resolve(id: Long, status: String, resolvedAt: Long = System.currentTimeMillis())
+
+    @Query("SELECT COUNT(*) FROM vows WHERE save_slot_id = :slotId AND status = 'active'")
+    fun observeActiveCount(slotId: Long): Flow<Int>
+}

--- a/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
@@ -5,9 +5,11 @@ import com.chimera.database.ChimeraGameDatabase
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
+import com.chimera.database.dao.VowDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,21 +27,12 @@ object DatabaseModule {
         return ChimeraGameDatabase.buildDatabase(context)
     }
 
-    @Provides
-    fun provideSaveSlotDao(db: ChimeraGameDatabase): SaveSlotDao = db.saveSlotDao()
-
-    @Provides
-    fun provideCharacterDao(db: ChimeraGameDatabase): CharacterDao = db.characterDao()
-
-    @Provides
-    fun provideCharacterStateDao(db: ChimeraGameDatabase): CharacterStateDao = db.characterStateDao()
-
-    @Provides
-    fun provideDialogueTurnDao(db: ChimeraGameDatabase): DialogueTurnDao = db.dialogueTurnDao()
-
-    @Provides
-    fun provideMemoryShardDao(db: ChimeraGameDatabase): MemoryShardDao = db.memoryShardDao()
-
-    @Provides
-    fun provideSceneInstanceDao(db: ChimeraGameDatabase): SceneInstanceDao = db.sceneInstanceDao()
+    @Provides fun provideSaveSlotDao(db: ChimeraGameDatabase): SaveSlotDao = db.saveSlotDao()
+    @Provides fun provideCharacterDao(db: ChimeraGameDatabase): CharacterDao = db.characterDao()
+    @Provides fun provideCharacterStateDao(db: ChimeraGameDatabase): CharacterStateDao = db.characterStateDao()
+    @Provides fun provideDialogueTurnDao(db: ChimeraGameDatabase): DialogueTurnDao = db.dialogueTurnDao()
+    @Provides fun provideMemoryShardDao(db: ChimeraGameDatabase): MemoryShardDao = db.memoryShardDao()
+    @Provides fun provideSceneInstanceDao(db: ChimeraGameDatabase): SceneInstanceDao = db.sceneInstanceDao()
+    @Provides fun provideJournalEntryDao(db: ChimeraGameDatabase): JournalEntryDao = db.journalEntryDao()
+    @Provides fun provideVowDao(db: ChimeraGameDatabase): VowDao = db.vowDao()
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/JournalEntryEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/JournalEntryEntity.kt
@@ -1,0 +1,45 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "journal_entries",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id"), Index("category")]
+)
+data class JournalEntryEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    val title: String,
+
+    val body: String,
+
+    val category: String, // story, rumor, companion, codex
+
+    @ColumnInfo(name = "scene_id")
+    val sceneId: String? = null,
+
+    @ColumnInfo(name = "character_id")
+    val characterId: String? = null,
+
+    @ColumnInfo(name = "is_read")
+    val isRead: Boolean = false,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/core-database/src/main/kotlin/com/chimera/database/entity/VowEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/VowEntity.kt
@@ -1,0 +1,43 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "vows",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id")]
+)
+data class VowEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    val description: String,
+
+    @ColumnInfo(name = "sworn_to")
+    val swornTo: String? = null, // character_id of NPC the vow was made to
+
+    val status: String = "active", // active, fulfilled, broken
+
+    @ColumnInfo(name = "scene_id_origin")
+    val sceneIdOrigin: String? = null,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+
+    @ColumnInfo(name = "resolved_at")
+    val resolvedAt: Long? = null
+)


### PR DESCRIPTION
## Summary

- **Journal system**: Tabbed screen (All/Story/Rumors/Vows/Companions) with unread badges, color-coded category cards, reactive ViewModel
- **Vow system**: Active/fulfilled/broken lifecycle, sworn-to NPC tracking, resolution timestamps
- **Camp screen**: Morale derived from companion dispositions, companion roster with avatar + disposition bar + mood labels, active vow reminders
- **Scene integration**: Dialogue completion auto-generates story journal entries
- **Database v3**: JournalEntryEntity + VowEntity with FKs and indices

## Test plan

- [ ] Journal tab shows empty state initially
- [ ] Complete a dialogue scene and verify story entry appears in journal
- [ ] Tab filtering works (Story/Rumors/Vows/Companions)
- [ ] Unread badge shows on All tab, clears when entry tapped
- [ ] Camp shows morale bar derived from companion dispositions
- [ ] Companion cards display name, title, mood label, disposition bar
- [ ] Active vows section appears when vows exist
- [ ] Vows tab in journal shows all vows with status colors

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb