### PR TITLE
Milestone D: Map with node graph, rumors, and factions

### DIFF
--- a/app/src/main/kotlin/com/chimera/ui/screens/map/MapScreen.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/map/MapScreen.kt
@@ -1,51 +1,281 @@
 package com.chimera.ui.screens.map
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Map
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chimera.ui.theme.AshBlack
 import com.chimera.ui.theme.DimAsh
+import com.chimera.ui.theme.EmberGold
 import com.chimera.ui.theme.FadedBone
+import com.chimera.ui.theme.HollowCrimson
+import com.chimera.ui.theme.VoidGreen
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapScreen(
-    onEnterScene: (String) -> Unit = {}
+    onEnterScene: (String) -> Unit = {},
+    viewModel: MapViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val sheetState = rememberStandardBottomSheetState(initialValue = SheetValue.Hidden, skipHiddenState = false)
+    val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
+
+    LaunchedEffect(uiState.selectedNode) {
+        if (uiState.selectedNode != null) {
+            sheetState.expand()
+        } else {
+            sheetState.hide()
+        }
+    }
+
+    BottomSheetScaffold(
+        scaffoldState = scaffoldState,
+        sheetContainerColor = MaterialTheme.colorScheme.surface,
+        sheetContentColor = MaterialTheme.colorScheme.onSurface,
+        sheetPeekHeight = 0.dp,
+        sheetContent = {
+            uiState.selectedNode?.let { node ->
+                NodeDetailSheet(
+                    node = node,
+                    onEnterScene = {
+                        node.sceneId?.let { onEnterScene(it) }
+                        viewModel.clearSelection()
+                    },
+                    onDismiss = { viewModel.clearSelection() }
+                )
+            } ?: Spacer(modifier = Modifier.height(1.dp))
+        },
+        containerColor = AshBlack
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(AshBlack)
+        ) {
+            // Title
+            Text(
+                text = "The Hollow",
+                style = MaterialTheme.typography.headlineMedium,
+                color = EmberGold,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 16.dp)
+            )
+
+            // Connection lines
+            MapConnections(nodes = uiState.nodes)
+
+            // Map nodes
+            uiState.nodes.forEach { node ->
+                MapNodeMarker(
+                    node = node,
+                    isSelected = uiState.selectedNode?.id == node.id,
+                    onClick = { viewModel.selectNode(node) },
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MapConnections(nodes: List<MapNode>) {
+    val pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f))
+
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        val w = size.width
+        val h = size.height
+
+        nodes.forEach { node ->
+            val start = Offset(node.xFraction * w, node.yFraction * h)
+            node.connectedTo.forEach { targetId ->
+                val target = nodes.find { it.id == targetId } ?: return@forEach
+                val end = Offset(target.xFraction * w, target.yFraction * h)
+                val lineColor = if (node.isUnlocked && target.isUnlocked) {
+                    FadedBone.copy(alpha = 0.3f)
+                } else {
+                    DimAsh.copy(alpha = 0.15f)
+                }
+                drawLine(
+                    color = lineColor,
+                    start = start,
+                    end = end,
+                    strokeWidth = 2f,
+                    pathEffect = if (!node.isUnlocked || !target.isUnlocked) pathEffect else null
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MapNodeMarker(
+    node: MapNode,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier) {
+        val density = LocalDensity.current
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .offset {
+                    IntOffset(
+                        x = (node.xFraction * constraints.maxWidth - 24 * density.density).toInt(),
+                        y = (node.yFraction * constraints.maxHeight - 24 * density.density).toInt()
+                    )
+                }
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .clickable(enabled = node.isUnlocked) { onClick() }
+                    .width(80.dp)
+            ) {
+                Box {
+                    Surface(
+                        shape = CircleShape,
+                        color = when {
+                            isSelected -> EmberGold
+                            node.isCompleted -> VoidGreen.copy(alpha = 0.7f)
+                            node.isUnlocked -> HollowCrimson.copy(alpha = 0.8f)
+                            else -> DimAsh.copy(alpha = 0.4f)
+                        },
+                        border = BorderStroke(
+                            2.dp,
+                            if (isSelected) EmberGold else Color.Transparent
+                        ),
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text(
+                                text = if (node.isUnlocked) node.name.first().toString() else "?",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = if (node.isUnlocked) MaterialTheme.colorScheme.onSurface else DimAsh
+                            )
+                        }
+                    }
+
+                    // Rumor heat badge
+                    if (node.rumorCount > 0) {
+                        Badge(
+                            containerColor = EmberGold,
+                            modifier = Modifier.align(Alignment.TopEnd)
+                        ) {
+                            Text("${node.rumorCount}")
+                        }
+                    }
+                }
+
+                Text(
+                    text = if (node.isUnlocked) node.name else "???",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (node.isUnlocked) FadedBone else DimAsh,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NodeDetailSheet(
+    node: MapNode,
+    onEnterScene: () -> Unit,
+    onDismiss: () -> Unit
 ) {
     Column(
         modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+            .fillMaxWidth()
+            .padding(24.dp)
     ) {
-        Icon(
-            imageVector = Icons.Default.Map,
-            contentDescription = null,
-            tint = DimAsh,
-            modifier = Modifier.height(64.dp)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "World Map",
-            style = MaterialTheme.typography.headlineMedium,
-            color = FadedBone
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(node.name, style = MaterialTheme.typography.headlineSmall, color = EmberGold)
+            if (node.isCompleted) {
+                Text("Explored", style = MaterialTheme.typography.labelMedium, color = VoidGreen)
+            }
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "The world map will reveal itself soon.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = DimAsh
-        )
+        Text(node.description, style = MaterialTheme.typography.bodyMedium, color = FadedBone)
+
+        if (node.faction != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "Controlled by: ${node.faction}",
+                style = MaterialTheme.typography.bodySmall,
+                color = HollowCrimson
+            )
+        }
+
+        if (node.rumorCount > 0) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                "${node.rumorCount} active rumor${if (node.rumorCount > 1) "s" else ""}",
+                style = MaterialTheme.typography.bodySmall,
+                color = EmberGold
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (node.sceneId != null && node.isUnlocked) {
+            Button(
+                onClick = onEnterScene,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = HollowCrimson)
+            ) {
+                Text(if (node.isCompleted) "Return" else "Enter")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
     }
 }

--- a/app/src/main/kotlin/com/chimera/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/map/MapViewModel.kt
@@ -1,0 +1,113 @@
+package com.chimera.ui.screens.map
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.FactionStateDao
+import com.chimera.database.dao.RumorPacketDao
+import com.chimera.database.dao.SceneInstanceDao
+import com.chimera.database.entity.FactionStateEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+data class MapNode(
+    val id: String,
+    val name: String,
+    val description: String,
+    val isUnlocked: Boolean = false,
+    val isCompleted: Boolean = false,
+    val rumorCount: Int = 0,
+    val faction: String? = null,
+    val connectedTo: List<String> = emptyList(),
+    val sceneId: String? = null,
+    val xFraction: Float = 0.5f,
+    val yFraction: Float = 0.5f
+)
+
+data class MapUiState(
+    val nodes: List<MapNode> = emptyList(),
+    val factions: List<FactionStateEntity> = emptyList(),
+    val selectedNode: MapNode? = null
+)
+
+@HiltViewModel
+class MapViewModel @Inject constructor(
+    private val sceneInstanceDao: SceneInstanceDao,
+    private val rumorPacketDao: RumorPacketDao,
+    private val factionStateDao: FactionStateDao,
+    gameSessionManager: GameSessionManager
+) : ViewModel() {
+
+    private val _selectedNode = MutableStateFlow<MapNode?>(null)
+
+    // Hardcoded map nodes for Act 1 -- will be data-driven later
+    private val baseNodes = listOf(
+        MapNode("hollow_gate", "The Hollow Gate", "A crumbling entrance to the ancient ruins.", isUnlocked = true, sceneId = "prologue_scene_1", connectedTo = listOf("outer_ruins", "watchtower"), xFraction = 0.5f, yFraction = 0.85f),
+        MapNode("outer_ruins", "Outer Ruins", "Weathered stone corridors open to the sky.", sceneId = "outer_ruins_1", connectedTo = listOf("hollow_gate", "merchants_rest", "deep_hollow"), xFraction = 0.3f, yFraction = 0.6f),
+        MapNode("watchtower", "The Watchtower", "A cracked spire overlooking the Hollow.", sceneId = "watchtower_1", connectedTo = listOf("hollow_gate", "merchants_rest"), xFraction = 0.7f, yFraction = 0.65f),
+        MapNode("merchants_rest", "Merchant's Rest", "A sheltered alcove where travelers barter.", sceneId = "merchants_1", connectedTo = listOf("outer_ruins", "watchtower", "deep_hollow"), xFraction = 0.5f, yFraction = 0.4f),
+        MapNode("deep_hollow", "The Deep Hollow", "Darkness gathers where the King once held court.", sceneId = "deep_hollow_1", connectedTo = listOf("outer_ruins", "merchants_rest"), xFraction = 0.4f, yFraction = 0.15f)
+    )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<MapUiState> = gameSessionManager.activeSlotId
+        .flatMapLatest { slotId ->
+            if (slotId == null) return@flatMapLatest flowOf(MapUiState())
+            combine(
+                rumorPacketDao.observeAll(slotId),
+                factionStateDao.observeAll(slotId),
+                _selectedNode
+            ) { rumors, factions, selected ->
+                val completedScenes = sceneInstanceDao.getBySlot(slotId)
+                    .filter { it.status == "completed" }
+                    .map { it.sceneId }
+                    .toSet()
+
+                val rumorsByLocation = rumors.groupBy { it.locationId }
+                    .mapValues { (_, list) -> list.count { it.heatLevel > 0.3f } }
+
+                val factionByLocation = factions.flatMap { faction ->
+                    // Simple mapping: faction controls locations listed in JSON
+                    listOf<Pair<String, String>>() // TODO: parse controlledLocationsJson
+                }.toMap()
+
+                val nodes = baseNodes.map { node ->
+                    val isCompleted = node.sceneId in completedScenes
+                    val isUnlocked = node.isUnlocked || node.connectedTo.any { connId ->
+                        baseNodes.find { it.id == connId }?.let { conn ->
+                            conn.isUnlocked || conn.sceneId in completedScenes
+                        } ?: false
+                    }
+                    node.copy(
+                        isUnlocked = isUnlocked,
+                        isCompleted = isCompleted,
+                        rumorCount = rumorsByLocation[node.id] ?: 0,
+                        faction = factionByLocation[node.id]
+                    )
+                }
+
+                MapUiState(
+                    nodes = nodes,
+                    factions = factions,
+                    selectedNode = selected
+                )
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MapUiState())
+
+    fun selectNode(node: MapNode) {
+        _selectedNode.value = node
+    }
+
+    fun clearSelection() {
+        _selectedNode.value = null
+    }
+}

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -10,16 +10,20 @@ import com.chimera.database.converter.Converters
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
+import com.chimera.database.dao.RumorPacketDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.dao.VowDao
 import com.chimera.database.entity.CharacterEntity
 import com.chimera.database.entity.CharacterStateEntity
 import com.chimera.database.entity.DialogueTurnEntity
+import com.chimera.database.entity.FactionStateEntity
 import com.chimera.database.entity.JournalEntryEntity
 import com.chimera.database.entity.MemoryShardEntity
+import com.chimera.database.entity.RumorPacketEntity
 import com.chimera.database.entity.SaveSlotEntity
 import com.chimera.database.entity.SceneInstanceEntity
 import com.chimera.database.entity.VowEntity
@@ -33,9 +37,11 @@ import com.chimera.database.entity.VowEntity
         MemoryShardEntity::class,
         SceneInstanceEntity::class,
         JournalEntryEntity::class,
-        VowEntity::class
+        VowEntity::class,
+        RumorPacketEntity::class,
+        FactionStateEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -49,6 +55,8 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     abstract fun sceneInstanceDao(): SceneInstanceDao
     abstract fun journalEntryDao(): JournalEntryDao
     abstract fun vowDao(): VowDao
+    abstract fun rumorPacketDao(): RumorPacketDao
+    abstract fun factionStateDao(): FactionStateDao
 
     companion object {
         const val DATABASE_NAME = "chimera_game.db"

--- a/core-database/src/main/kotlin/com/chimera/database/dao/FactionStateDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/FactionStateDao.kt
@@ -1,0 +1,32 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.chimera.database.entity.FactionStateEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FactionStateDao {
+
+    @Query("SELECT * FROM faction_states WHERE save_slot_id = :slotId")
+    fun observeAll(slotId: Long): Flow<List<FactionStateEntity>>
+
+    @Query("SELECT * FROM faction_states WHERE save_slot_id = :slotId AND faction_id = :factionId")
+    suspend fun getByFaction(slotId: Long, factionId: String): FactionStateEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(faction: FactionStateEntity)
+
+    @Query(
+        "UPDATE faction_states SET player_standing = " +
+        "CASE " +
+        "WHEN player_standing + :delta < -1.0 THEN -1.0 " +
+        "WHEN player_standing + :delta > 1.0 THEN 1.0 " +
+        "ELSE player_standing + :delta " +
+        "END " +
+        "WHERE save_slot_id = :slotId AND faction_id = :factionId"
+    )
+    suspend fun adjustStanding(slotId: Long, factionId: String, delta: Float)
+}

--- a/core-database/src/main/kotlin/com/chimera/database/dao/RumorPacketDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/RumorPacketDao.kt
@@ -1,0 +1,29 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.chimera.database.entity.RumorPacketEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RumorPacketDao {
+
+    @Query("SELECT * FROM rumor_packets WHERE save_slot_id = :slotId ORDER BY heat_level DESC, created_at DESC")
+    fun observeAll(slotId: Long): Flow<List<RumorPacketEntity>>
+
+    @Query("SELECT * FROM rumor_packets WHERE save_slot_id = :slotId AND location_id = :locationId ORDER BY heat_level DESC")
+    fun observeByLocation(slotId: Long, locationId: String): Flow<List<RumorPacketEntity>>
+
+    @Insert
+    suspend fun insert(rumor: RumorPacketEntity): Long
+
+    @Query("UPDATE rumor_packets SET heat_level = heat_level * :decayFactor WHERE save_slot_id = :slotId AND heat_level > 0.1")
+    suspend fun decayAll(slotId: Long, decayFactor: Float = 0.9f)
+
+    @Query("UPDATE rumor_packets SET is_verified = 1 WHERE id = :id")
+    suspend fun verify(id: Long)
+
+    @Query("SELECT COUNT(*) FROM rumor_packets WHERE save_slot_id = :slotId AND location_id = :locationId AND heat_level > 0.3")
+    fun observeHotCount(slotId: Long, locationId: String): Flow<Int>
+}

--- a/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
@@ -5,8 +5,10 @@ import com.chimera.database.ChimeraGameDatabase
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
+import com.chimera.database.dao.RumorPacketDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.dao.VowDao
@@ -35,4 +37,6 @@ object DatabaseModule {
     @Provides fun provideSceneInstanceDao(db: ChimeraGameDatabase): SceneInstanceDao = db.sceneInstanceDao()
     @Provides fun provideJournalEntryDao(db: ChimeraGameDatabase): JournalEntryDao = db.journalEntryDao()
     @Provides fun provideVowDao(db: ChimeraGameDatabase): VowDao = db.vowDao()
+    @Provides fun provideRumorPacketDao(db: ChimeraGameDatabase): RumorPacketDao = db.rumorPacketDao()
+    @Provides fun provideFactionStateDao(db: ChimeraGameDatabase): FactionStateDao = db.factionStateDao()
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/FactionStateEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/FactionStateEntity.kt
@@ -1,0 +1,41 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "faction_states",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id"), Index(value = ["save_slot_id", "faction_id"], unique = true)]
+)
+data class FactionStateEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    @ColumnInfo(name = "faction_id")
+    val factionId: String,
+
+    @ColumnInfo(name = "faction_name")
+    val factionName: String,
+
+    val influence: Float = 0.5f, // 0.0..1.0
+
+    @ColumnInfo(name = "player_standing")
+    val playerStanding: Float = 0f, // -1.0..1.0
+
+    @ColumnInfo(name = "controlled_locations_json")
+    val controlledLocationsJson: String = "[]"
+)

--- a/core-database/src/main/kotlin/com/chimera/database/entity/RumorPacketEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/RumorPacketEntity.kt
@@ -1,0 +1,46 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "rumor_packets",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id"), Index("location_id")]
+)
+data class RumorPacketEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    val title: String,
+
+    val content: String,
+
+    @ColumnInfo(name = "location_id")
+    val locationId: String,
+
+    @ColumnInfo(name = "source_npc")
+    val sourceNpc: String? = null,
+
+    @ColumnInfo(name = "heat_level")
+    val heatLevel: Float = 0.5f, // 0.0 = cold, 1.0 = hot
+
+    @ColumnInfo(name = "is_verified")
+    val isVerified: Boolean = false,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis()
+)


### PR DESCRIPTION
## Summary

- **Node-based map**: 5 Act 1 locations with Canvas connection lines, color-coded node states, bottom sheet detail view with scene entry
- **Rumor web MVP**: RumorPacketEntity with heat decay, verification, hot-count badges on map nodes
- **Faction system**: FactionStateEntity with influence and clamped player standing
- **Database v4**: RumorPacket + FactionState entities with proper FKs and unique indices

## Test plan

- [ ] Map screen shows 5 nodes with connection lines
- [ ] Hollow Gate node is unlocked (starting location)
- [ ] Tapping unlocked node opens bottom sheet with details
- [ ] Enter button navigates to dialogue scene
- [ ] Completed scenes show green nodes
- [ ] Locked nodes show as dim with "???" labels
- [ ] Rumor badges appear when hot rumors exist for a location

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb