### PR TITLE
Sprint 2: Unit tests for DuelEngine, Converters, EntityMappers, Orchestrator

### DIFF
--- a/app/src/test/kotlin/com/chimera/ai/DialogueOrchestratorTest.kt
+++ b/app/src/test/kotlin/com/chimera/ai/DialogueOrchestratorTest.kt
@@ -1,0 +1,130 @@
+package com.chimera.ai
+
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DialogueOrchestratorTest {
+
+    private lateinit var orchestrator: DialogueOrchestrator
+    private lateinit var fakeProvider: FakeDialogueProvider
+
+    private val contract = SceneContract(
+        sceneId = "test_scene",
+        sceneTitle = "Test Scene",
+        npcId = "npc_test",
+        npcName = "Test NPC",
+        setting = "a test room"
+    )
+
+    private val defaultState = CharacterState(characterId = "npc_test", saveSlotId = 1)
+
+    @Before
+    fun setup() {
+        fakeProvider = FakeDialogueProvider()
+        orchestrator = DialogueOrchestrator(fakeProvider)
+    }
+
+    @Test
+    fun `generateTurn returns valid result from fallback`() = runTest {
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("Hello"),
+            defaultState
+        )
+        assertTrue(result.npcLine.isNotBlank())
+        assertTrue(orchestrator.isFallbackActive)
+    }
+
+    @Test
+    fun `output validation clamps relationship delta`() = runTest {
+        // Kind input with positive disposition should get positive delta
+        val kindState = defaultState.copy(dispositionToPlayer = 0.5f)
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("Thank you friend, I trust you"),
+            kindState,
+            turnHistory = listOf(
+                DialogueTurnResult(npcLine = "previous line")
+            )
+        )
+        // Delta should be clamped to [-0.25, 0.25]
+        assertTrue(result.relationshipDelta >= -0.25f)
+        assertTrue(result.relationshipDelta <= 0.25f)
+    }
+
+    @Test
+    fun `output validation limits memory candidates to 3`() = runTest {
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("Tell me everything you know"),
+            defaultState
+        )
+        assertTrue(result.memoryCandidates.size <= 3)
+    }
+
+    @Test
+    fun `output validation replaces blank npc line`() = runTest {
+        // FakeDialogueProvider shouldn't produce blank lines, but the
+        // orchestrator validates just in case
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("test input"),
+            defaultState
+        )
+        assertTrue(result.npcLine.isNotBlank())
+    }
+
+    @Test
+    fun `generateIntents returns non-empty list`() = runTest {
+        val intents = orchestrator.generateIntents(contract, defaultState)
+        assertTrue(intents.isNotEmpty())
+        assertTrue(intents.size <= 5)
+    }
+
+    @Test
+    fun `isFallbackActive is true when no primary provider set`() = runTest {
+        orchestrator.generateTurn(contract, PlayerInput("test"), defaultState)
+        assertTrue(orchestrator.isFallbackActive)
+    }
+
+    @Test
+    fun `threatening input produces negative delta`() = runTest {
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("I will destroy you"),
+            defaultState
+        )
+        assertTrue(result.relationshipDelta < 0f)
+    }
+
+    @Test
+    fun `kind input with high disposition produces grateful response`() = runTest {
+        val kindState = defaultState.copy(dispositionToPlayer = 0.5f)
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("I want to help you, please trust me"),
+            kindState,
+            turnHistory = listOf(DialogueTurnResult(npcLine = "opening"))
+        )
+        assertEquals("grateful", result.emotion)
+    }
+
+    @Test
+    fun `question input produces thoughtful response`() = runTest {
+        val result = orchestrator.generateTurn(
+            contract,
+            PlayerInput("What happened here?"),
+            defaultState,
+            turnHistory = listOf(DialogueTurnResult(npcLine = "opening"))
+        )
+        assertEquals("thoughtful", result.emotion)
+    }
+}

--- a/app/src/test/kotlin/com/chimera/ui/screens/duel/DuelEngineTest.kt
+++ b/app/src/test/kotlin/com/chimera/ui/screens/duel/DuelEngineTest.kt
@@ -1,0 +1,199 @@
+package com.chimera.ui.screens.duel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DuelEngineTest {
+
+    private fun createEngine(
+        opponentResolve: Int = 3,
+        playerModifier: Float = 0f
+    ) = DuelEngine("Player", "Opponent", opponentResolve, playerModifier)
+
+    @Test
+    fun `initial state has correct defaults`() {
+        val engine = createEngine()
+        val state = engine.getState()
+        assertEquals(0, state.round)
+        assertEquals(2, state.playerOmens)
+        assertEquals(3, state.opponentResolve)
+        assertFalse(state.isComplete)
+        assertNull(state.playerWon)
+        assertTrue(state.log.isEmpty())
+    }
+
+    @Test
+    fun `strike beats feint`() {
+        // Stance.STRIKE.beats == "Feint"
+        val strike = DuelEngine.Stance.STRIKE
+        assertEquals("Feint", strike.beats)
+    }
+
+    @Test
+    fun `ward beats strike`() {
+        val ward = DuelEngine.Stance.WARD
+        assertEquals("Strike", ward.beats)
+    }
+
+    @Test
+    fun `feint beats ward`() {
+        val feint = DuelEngine.Stance.FEINT
+        assertEquals("Ward", feint.beats)
+    }
+
+    @Test
+    fun `round increments after each execution`() {
+        val engine = createEngine()
+        engine.executeRound(DuelEngine.Stance.STRIKE)
+        assertEquals(1, engine.getState().round)
+        engine.executeRound(DuelEngine.Stance.WARD)
+        assertEquals(2, engine.getState().round)
+    }
+
+    @Test
+    fun `win increases omens and decreases opponent resolve`() {
+        val engine = createEngine()
+        val initial = engine.getState()
+        val result = engine.executeRound(DuelEngine.Stance.STRIKE)
+
+        val state = engine.getState()
+        if (result.outcome == DuelEngine.RoundOutcome.WIN) {
+            assertEquals(initial.opponentResolve - 1, state.opponentResolve)
+            assertEquals((initial.playerOmens + 1).coerceAtMost(4), state.playerOmens)
+        }
+    }
+
+    @Test
+    fun `loss decreases player omens`() {
+        val engine = createEngine()
+        val initial = engine.getState()
+        val result = engine.executeRound(DuelEngine.Stance.STRIKE)
+
+        val state = engine.getState()
+        if (result.outcome == DuelEngine.RoundOutcome.LOSE) {
+            assertEquals((initial.playerOmens - 1).coerceAtLeast(0), state.playerOmens)
+        }
+    }
+
+    @Test
+    fun `draw changes nothing`() {
+        val engine = createEngine()
+        val initial = engine.getState()
+        val result = engine.executeRound(DuelEngine.Stance.STRIKE)
+
+        if (result.outcome == DuelEngine.RoundOutcome.DRAW) {
+            val state = engine.getState()
+            assertEquals(initial.playerOmens, state.playerOmens)
+            assertEquals(initial.opponentResolve, state.opponentResolve)
+        }
+    }
+
+    @Test
+    fun `omens capped at 4`() {
+        val engine = createEngine()
+        // Run multiple rounds; omens should never exceed 4
+        repeat(7) {
+            if (!engine.getState().isComplete) {
+                engine.executeRound(DuelEngine.Stance.STRIKE)
+            }
+        }
+        assertTrue(engine.getState().playerOmens <= 4)
+    }
+
+    @Test
+    fun `omens cannot go below 0`() {
+        val engine = createEngine()
+        repeat(7) {
+            if (!engine.getState().isComplete) {
+                engine.executeRound(DuelEngine.Stance.WARD)
+            }
+        }
+        assertTrue(engine.getState().playerOmens >= 0)
+    }
+
+    @Test
+    fun `duel ends when opponent resolve reaches 0`() {
+        val engine = createEngine(opponentResolve = 1)
+        // With resolve=1, a single win should end the duel
+        var attempts = 0
+        while (!engine.getState().isComplete && attempts < 20) {
+            engine.executeRound(DuelEngine.Stance.STRIKE)
+            attempts++
+        }
+        assertTrue(engine.getState().isComplete)
+    }
+
+    @Test
+    fun `duel ends after 7 rounds maximum`() {
+        val engine = createEngine(opponentResolve = 100) // high resolve so it doesn't end early
+        repeat(7) {
+            if (!engine.getState().isComplete) {
+                engine.executeRound(DuelEngine.Stance.STRIKE)
+            }
+        }
+        assertTrue(engine.getState().isComplete)
+        assertEquals(7, engine.getState().round)
+    }
+
+    @Test
+    fun `player wins when opponent resolve reaches 0`() {
+        val engine = createEngine(opponentResolve = 1)
+        var result: DuelEngine.RoundResult
+        var attempts = 0
+        do {
+            result = engine.executeRound(DuelEngine.Stance.STRIKE)
+            attempts++
+        } while (!engine.getState().isComplete && attempts < 20)
+
+        if (engine.getState().opponentResolve <= 0) {
+            assertEquals(true, engine.getState().playerWon)
+        }
+    }
+
+    @Test
+    fun `round result contains narrative text`() {
+        val engine = createEngine()
+        val result = engine.executeRound(DuelEngine.Stance.STRIKE)
+        assertTrue(result.narrative.isNotBlank())
+        assertNotNull(result.playerStance)
+        assertNotNull(result.opponentStance)
+    }
+
+    @Test
+    fun `log accumulates all round results`() {
+        val engine = createEngine()
+        repeat(3) {
+            if (!engine.getState().isComplete) {
+                engine.executeRound(DuelEngine.Stance.values().random())
+            }
+        }
+        assertEquals(engine.getState().round, engine.getState().log.size)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `executing round after completion throws`() {
+        val engine = createEngine(opponentResolve = 1)
+        // Force completion
+        repeat(20) {
+            if (!engine.getState().isComplete) {
+                engine.executeRound(DuelEngine.Stance.STRIKE)
+            }
+        }
+        assertTrue(engine.getState().isComplete)
+        // This should throw
+        engine.executeRound(DuelEngine.Stance.STRIKE)
+    }
+
+    @Test
+    fun `player modifier is clamped to valid range`() {
+        // Extreme modifier should be clamped internally
+        val engine = createEngine(playerModifier = 5.0f)
+        val result = engine.executeRound(DuelEngine.Stance.STRIKE)
+        // Should not crash -- modifier is clamped to -0.3..0.3
+        assertNotNull(result)
+    }
+}

--- a/core-database/src/test/kotlin/com/chimera/database/converter/ConvertersTest.kt
+++ b/core-database/src/test/kotlin/com/chimera/database/converter/ConvertersTest.kt
@@ -1,0 +1,68 @@
+package com.chimera.database.converter
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConvertersTest {
+
+    private val converters = Converters()
+
+    @Test
+    fun `fromFloatMap serializes empty map`() {
+        val result = converters.fromFloatMap(emptyMap())
+        assertEquals("{}", result)
+    }
+
+    @Test
+    fun `fromFloatMap serializes populated map`() {
+        val map = mapOf("joy" to 0.8f, "anger" to 0.3f)
+        val json = converters.fromFloatMap(map)
+        assertTrue(json.contains("joy"))
+        assertTrue(json.contains("anger"))
+    }
+
+    @Test
+    fun `toFloatMap deserializes valid JSON`() {
+        val json = """{"joy":0.8,"anger":0.3}"""
+        val map = converters.toFloatMap(json)
+        assertEquals(2, map.size)
+        assertEquals(0.8f, map["joy"]!!, 0.01f)
+        assertEquals(0.3f, map["anger"]!!, 0.01f)
+    }
+
+    @Test
+    fun `toFloatMap returns empty map for malformed JSON`() {
+        val result = converters.toFloatMap("not valid json")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `toFloatMap returns empty map for empty string`() {
+        val result = converters.toFloatMap("")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `toFloatMap returns empty map for null-like JSON`() {
+        val result = converters.toFloatMap("null")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `round trip preserves data`() {
+        val original = mapOf("trust" to 0.75f, "fear" to 0.1f, "hope" to 0.5f)
+        val json = converters.fromFloatMap(original)
+        val restored = converters.toFloatMap(json)
+        assertEquals(original.size, restored.size)
+        original.forEach { (key, value) ->
+            assertEquals(value, restored[key]!!, 0.001f)
+        }
+    }
+
+    @Test
+    fun `handles empty JSON object`() {
+        val result = converters.toFloatMap("{}")
+        assertTrue(result.isEmpty())
+    }
+}

--- a/core-database/src/test/kotlin/com/chimera/database/mapper/EntityMappersTest.kt
+++ b/core-database/src/test/kotlin/com/chimera/database/mapper/EntityMappersTest.kt
@@ -1,0 +1,129 @@
+package com.chimera.database.mapper
+
+import com.chimera.database.entity.CharacterEntity
+import com.chimera.database.entity.CharacterStateEntity
+import com.chimera.database.entity.MemoryShardEntity
+import com.chimera.database.entity.SaveSlotEntity
+import com.chimera.model.Character
+import com.chimera.model.CharacterRole
+import com.chimera.model.CharacterState
+import com.chimera.model.MemoryShard
+import com.chimera.model.SaveSlot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EntityMappersTest {
+
+    @Test
+    fun `SaveSlotEntity round trip preserves all fields`() {
+        val model = SaveSlot(
+            id = 1, slotIndex = 0, playerName = "Arthas",
+            chapterTag = "act_1", playtimeSeconds = 3600,
+            lastPlayedAt = 1000L, createdAt = 500L, isEmpty = false
+        )
+        val entity = model.toEntity()
+        val restored = entity.toModel()
+        assertEquals(model, restored)
+    }
+
+    @Test
+    fun `CharacterEntity round trip preserves all fields`() {
+        val model = Character(
+            id = "npc_1", saveSlotId = 1, name = "Elena",
+            title = "The Merchant", role = CharacterRole.NPC_ALLY,
+            isPlayerCharacter = false, portraitResName = "elena_portrait"
+        )
+        val entity = model.toEntity()
+        val restored = entity.toModel()
+        assertEquals(model, restored)
+    }
+
+    @Test
+    fun `CharacterEntity handles invalid role gracefully`() {
+        val entity = CharacterEntity(
+            id = "npc_bad", saveSlotId = 1, name = "Unknown",
+            role = "INVALID_ROLE"
+        )
+        val model = entity.toModel()
+        assertEquals(CharacterRole.NPC_NEUTRAL, model.role)
+    }
+
+    @Test
+    fun `CharacterStateEntity clamps disposition to valid range`() {
+        val entity = CharacterStateEntity(
+            characterId = "npc_1", saveSlotId = 1,
+            dispositionToPlayer = 5.0f, // out of range
+            healthFraction = 2.0f // out of range
+        )
+        val model = entity.toModel()
+        assertEquals(1.0f, model.dispositionToPlayer, 0.001f)
+        assertEquals(1.0f, model.healthFraction, 0.001f)
+    }
+
+    @Test
+    fun `CharacterStateEntity clamps negative disposition`() {
+        val entity = CharacterStateEntity(
+            characterId = "npc_1", saveSlotId = 1,
+            dispositionToPlayer = -5.0f
+        )
+        val model = entity.toModel()
+        assertEquals(-1.0f, model.dispositionToPlayer, 0.001f)
+    }
+
+    @Test
+    fun `CharacterState round trip preserves emotional state`() {
+        val model = CharacterState(
+            characterId = "npc_1", saveSlotId = 1,
+            emotionalState = mapOf("joy" to 0.8f, "fear" to 0.2f),
+            archetypeVariables = mapOf("dependency" to 0.5f)
+        )
+        val entity = model.toEntity()
+        val restored = entity.toModel()
+        assertEquals(model.emotionalState, restored.emotionalState)
+        assertEquals(model.archetypeVariables, restored.archetypeVariables)
+    }
+
+    @Test
+    fun `MemoryShardEntity toModel maps all fields`() {
+        val entity = MemoryShardEntity(
+            id = 42, saveSlotId = 1, sceneId = "scene_1",
+            characterId = "npc_1", summary = "Player showed kindness",
+            importanceScore = 0.9f, createdAt = 12345L
+        )
+        val model = entity.toModel()
+        assertEquals(42L, model.id)
+        assertEquals(1L, model.saveSlotId)
+        assertEquals("scene_1", model.sceneId)
+        assertEquals("npc_1", model.characterId)
+        assertEquals("Player showed kindness", model.summary)
+        assertEquals(0.9f, model.importanceScore, 0.001f)
+        assertEquals(12345L, model.createdAt)
+    }
+
+    @Test
+    fun `MemoryShard round trip preserves core fields`() {
+        val model = MemoryShard(
+            id = 10, saveSlotId = 1, sceneId = "s1",
+            characterId = "c1", summary = "Test memory",
+            importanceScore = 0.7f, createdAt = 9999L
+        )
+        val entity = model.toEntity()
+        val restored = entity.toModel()
+        assertEquals(model.id, restored.id)
+        assertEquals(model.summary, restored.summary)
+        assertEquals(model.importanceScore, restored.importanceScore, 0.001f)
+    }
+
+    @Test
+    fun `CharacterStateEntity handles empty JSON strings`() {
+        val entity = CharacterStateEntity(
+            characterId = "npc_1", saveSlotId = 1,
+            emotionalStateJson = "{}",
+            archetypeVariablesJson = "{}"
+        )
+        val model = entity.toModel()
+        assertTrue(model.emotionalState.isEmpty())
+        assertTrue(model.archetypeVariables.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

Partial close of #46 -- adds 42 unit tests across all 3 modules:

- **DuelEngineTest** (16): stance resolution, omen/resolve boundaries, 7-round cap, completion guard, modifier clamping
- **ConvertersTest** (7): float map round-trip, malformed JSON, empty/null edge cases
- **EntityMappersTest** (10): round-trip all entity types, disposition clamping, invalid role fallback
- **DialogueOrchestratorTest** (9): fallback activation, delta clamping, memory limits, tone detection

DAO instrumented tests deferred (require Android test runner).

## Test plan

- [ ] `./gradlew :app:test` passes all DuelEngine and Orchestrator tests
- [ ] `./gradlew :core-database:test` passes Converter and Mapper tests
- [ ] No existing tests broken

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb