### PR TITLE
Sprint 5: Data-driven scenes and map from JSON assets

### DIFF
--- a/app/src/main/assets/act1_map.json
+++ b/app/src/main/assets/act1_map.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "hollow_gate",
+    "name": "The Hollow Gate",
+    "description": "A crumbling entrance to the ancient ruins. The stones hum with fading wards.",
+    "isUnlocked": true,
+    "sceneId": "prologue_scene_1",
+    "connectedTo": ["outer_ruins", "watchtower"],
+    "xFraction": 0.5,
+    "yFraction": 0.85
+  },
+  {
+    "id": "outer_ruins",
+    "name": "Outer Ruins",
+    "description": "Weathered stone corridors open to the sky. Merchants and scavengers pass through.",
+    "sceneId": "outer_ruins_1",
+    "connectedTo": ["hollow_gate", "merchants_rest", "deep_hollow"],
+    "xFraction": 0.3,
+    "yFraction": 0.6
+  },
+  {
+    "id": "watchtower",
+    "name": "The Watchtower",
+    "description": "A cracked spire overlooking the Hollow. Guards keep watch from its heights.",
+    "sceneId": "watchtower_1",
+    "connectedTo": ["hollow_gate", "merchants_rest"],
+    "xFraction": 0.7,
+    "yFraction": 0.65
+  },
+  {
+    "id": "merchants_rest",
+    "name": "Merchant's Rest",
+    "description": "A sheltered alcove where travelers barter goods and share rumors.",
+    "sceneId": "merchants_1",
+    "connectedTo": ["outer_ruins", "watchtower", "deep_hollow"],
+    "xFraction": 0.5,
+    "yFraction": 0.4
+  },
+  {
+    "id": "deep_hollow",
+    "name": "The Deep Hollow",
+    "description": "Darkness gathers where the King once held court. Few return unchanged.",
+    "sceneId": "deep_hollow_1",
+    "connectedTo": ["outer_ruins", "merchants_rest"],
+    "xFraction": 0.4,
+    "yFraction": 0.15,
+    "unlockRequirements": {
+      "minDisposition": { "warden": 0.1 },
+      "completedScenes": ["prologue_scene_1"]
+    }
+  }
+]

--- a/app/src/main/assets/act1_scenes.json
+++ b/app/src/main/assets/act1_scenes.json
@@ -1,0 +1,49 @@
+[
+  {
+    "sceneId": "prologue_scene_1",
+    "sceneTitle": "The Hollow Threshold",
+    "npcId": "warden",
+    "npcName": "The Warden",
+    "setting": "the crumbling gates of the Hollow",
+    "stakes": "First contact with a gatekeeper who controls access to the ruins",
+    "maxTurns": 12
+  },
+  {
+    "sceneId": "outer_ruins_1",
+    "sceneTitle": "Whispers in Stone",
+    "npcId": "elena",
+    "npcName": "Elena the Merchant",
+    "setting": "weathered corridors open to the sky",
+    "stakes": "A traveling merchant offers supplies but demands a steep price",
+    "maxTurns": 10
+  },
+  {
+    "sceneId": "watchtower_1",
+    "sceneTitle": "The Cracked Spire",
+    "npcId": "marcus",
+    "npcName": "Marcus the Guard",
+    "setting": "atop a watchtower overlooking the Hollow",
+    "stakes": "A suspicious guard questions your intentions and loyalty",
+    "maxTurns": 10
+  },
+  {
+    "sceneId": "merchants_1",
+    "sceneTitle": "Barter and Bone",
+    "npcId": "aria",
+    "npcName": "Aria the Scholar",
+    "setting": "a sheltered alcove where travelers barter",
+    "stakes": "A scholar seeks a research partner but hides a dangerous agenda",
+    "maxTurns": 12
+  },
+  {
+    "sceneId": "deep_hollow_1",
+    "sceneTitle": "The Throne of Ashes",
+    "npcId": "hollow_king",
+    "npcName": "The Hollow King's Echo",
+    "setting": "the dark heart where the King once held court",
+    "stakes": "A spectral echo offers power at a terrible cost",
+    "maxTurns": 8,
+    "allowedReveals": ["king_history", "corruption_source"],
+    "forbiddenTopics": ["escape_route"]
+  }
+]

--- a/app/src/main/assets/npcs.json
+++ b/app/src/main/assets/npcs.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "warden",
+    "name": "The Warden",
+    "title": "Keeper of the Gate",
+    "role": "NPC_NEUTRAL",
+    "initialDisposition": 0.0,
+    "archetype": "SHIFTING_THE_BURDEN",
+    "portraitResName": null
+  },
+  {
+    "id": "elena",
+    "name": "Elena",
+    "title": "The Merchant",
+    "role": "NPC_ALLY",
+    "initialDisposition": 0.1,
+    "archetype": "GROWTH_AND_UNDERINVESTMENT",
+    "portraitResName": null
+  },
+  {
+    "id": "marcus",
+    "name": "Marcus",
+    "title": "The Guard",
+    "role": "NPC_HOSTILE",
+    "initialDisposition": -0.2,
+    "archetype": "ESCALATION",
+    "portraitResName": null
+  },
+  {
+    "id": "aria",
+    "name": "Aria",
+    "title": "The Scholar",
+    "role": "COMPANION",
+    "initialDisposition": 0.2,
+    "archetype": "FIXES_THAT_FAIL",
+    "portraitResName": null
+  },
+  {
+    "id": "hollow_king",
+    "name": "The Hollow King's Echo",
+    "title": "Shade of the Fallen",
+    "role": "FACTION_LEADER",
+    "initialDisposition": -0.5,
+    "archetype": null,
+    "portraitResName": null
+  }
+]

--- a/app/src/main/kotlin/com/chimera/data/MapNodeLoader.kt
+++ b/app/src/main/kotlin/com/chimera/data/MapNodeLoader.kt
@@ -1,0 +1,48 @@
+package com.chimera.data
+
+import android.content.Context
+import com.chimera.ui.screens.map.MapNode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Serializable
+private data class MapNodeJson(
+    val id: String,
+    val name: String,
+    val description: String,
+    val isUnlocked: Boolean = false,
+    val sceneId: String? = null,
+    val connectedTo: List<String> = emptyList(),
+    val xFraction: Float = 0.5f,
+    val yFraction: Float = 0.5f
+)
+
+@Singleton
+class MapNodeLoader @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private var cache: List<MapNode>? = null
+
+    fun loadNodes(): List<MapNode> {
+        cache?.let { return it }
+        val text = context.assets.open("act1_map.json").bufferedReader().use { it.readText() }
+        val nodes = json.decodeFromString<List<MapNodeJson>>(text).map { it.toMapNode() }
+        cache = nodes
+        return nodes
+    }
+
+    private fun MapNodeJson.toMapNode() = MapNode(
+        id = id,
+        name = name,
+        description = description,
+        isUnlocked = isUnlocked,
+        sceneId = sceneId,
+        connectedTo = connectedTo,
+        xFraction = xFraction,
+        yFraction = yFraction
+    )
+}

--- a/app/src/main/kotlin/com/chimera/data/SceneLoader.kt
+++ b/app/src/main/kotlin/com/chimera/data/SceneLoader.kt
@@ -1,0 +1,33 @@
+package com.chimera.data
+
+import android.content.Context
+import com.chimera.model.SceneContract
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SceneLoader @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private var cache: Map<String, SceneContract>? = null
+
+    fun getScene(sceneId: String): SceneContract? {
+        return loadAll()[sceneId]
+    }
+
+    fun getAllScenes(): List<SceneContract> {
+        return loadAll().values.toList()
+    }
+
+    private fun loadAll(): Map<String, SceneContract> {
+        cache?.let { return it }
+        val text = context.assets.open("act1_scenes.json").bufferedReader().use { it.readText() }
+        val scenes = json.decodeFromString<List<SceneContract>>(text)
+        val map = scenes.associateBy { it.sceneId }
+        cache = map
+        return map
+    }
+}

--- a/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chimera.ai.DialogueOrchestrator
 import com.chimera.data.GameSessionManager
+import com.chimera.data.SceneLoader
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
 import com.chimera.database.dao.JournalEntryDao
@@ -64,6 +65,7 @@ class DialogueSceneViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val orchestrator: DialogueOrchestrator,
     private val gameSessionManager: GameSessionManager,
+    private val sceneLoader: SceneLoader,
     private val dialogueTurnDao: DialogueTurnDao,
     private val sceneInstanceDao: SceneInstanceDao,
     private val memoryShardDao: MemoryShardDao,
@@ -84,13 +86,12 @@ class DialogueSceneViewModel @Inject constructor(
         private const val MAX_TURN_HISTORY = 20
     }
 
-    private val contract = SceneContract(
+    private val contract: SceneContract = sceneLoader.getScene(sceneId) ?: SceneContract(
         sceneId = sceneId,
-        sceneTitle = "The Hollow Threshold",
-        npcId = "warden",
-        npcName = "The Warden",
-        setting = "the crumbling gates of the Hollow",
-        stakes = "First contact with a gatekeeper who controls access to the ruins"
+        sceneTitle = "Unknown Scene",
+        npcId = "unknown",
+        npcName = "Stranger",
+        setting = "an unfamiliar place"
     )
 
     init {

--- a/app/src/main/kotlin/com/chimera/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/map/MapViewModel.kt
@@ -3,6 +3,7 @@ package com.chimera.ui.screens.map
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chimera.data.GameSessionManager
+import com.chimera.data.MapNodeLoader
 import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.RumorPacketDao
 import com.chimera.database.dao.SceneInstanceDao
@@ -43,19 +44,12 @@ class MapViewModel @Inject constructor(
     private val sceneInstanceDao: SceneInstanceDao,
     private val rumorPacketDao: RumorPacketDao,
     private val factionStateDao: FactionStateDao,
+    private val mapNodeLoader: MapNodeLoader,
     gameSessionManager: GameSessionManager
 ) : ViewModel() {
 
     private val _selectedNode = MutableStateFlow<MapNode?>(null)
-
-    // Hardcoded map nodes for Act 1 -- will be data-driven later
-    private val baseNodes = listOf(
-        MapNode("hollow_gate", "The Hollow Gate", "A crumbling entrance to the ancient ruins.", isUnlocked = true, sceneId = "prologue_scene_1", connectedTo = listOf("outer_ruins", "watchtower"), xFraction = 0.5f, yFraction = 0.85f),
-        MapNode("outer_ruins", "Outer Ruins", "Weathered stone corridors open to the sky.", sceneId = "outer_ruins_1", connectedTo = listOf("hollow_gate", "merchants_rest", "deep_hollow"), xFraction = 0.3f, yFraction = 0.6f),
-        MapNode("watchtower", "The Watchtower", "A cracked spire overlooking the Hollow.", sceneId = "watchtower_1", connectedTo = listOf("hollow_gate", "merchants_rest"), xFraction = 0.7f, yFraction = 0.65f),
-        MapNode("merchants_rest", "Merchant's Rest", "A sheltered alcove where travelers barter.", sceneId = "merchants_1", connectedTo = listOf("outer_ruins", "watchtower", "deep_hollow"), xFraction = 0.5f, yFraction = 0.4f),
-        MapNode("deep_hollow", "The Deep Hollow", "Darkness gathers where the King once held court.", sceneId = "deep_hollow_1", connectedTo = listOf("outer_ruins", "merchants_rest"), xFraction = 0.4f, yFraction = 0.15f)
-    )
+    private val baseNodes: List<MapNode> by lazy { mapNodeLoader.loadNodes() }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val uiState: StateFlow<MapUiState> = gameSessionManager.activeSlotId


### PR DESCRIPTION
## Summary

Closes #49

- **JSON assets**: `act1_scenes.json` (5 scenes), `act1_map.json` (5 nodes), `npcs.json` (5 NPCs)
- **SceneLoader**: Reads scene contracts from assets, caches in memory, used by DialogueSceneViewModel
- **MapNodeLoader**: Reads map nodes from assets, caches in memory, used by MapViewModel
- **No more hardcoded data** -- DialogueSceneViewModel and MapViewModel fully data-driven

## Test plan

- [ ] Enter prologue scene -- title/NPC loads from JSON
- [ ] Enter different scenes -- each shows correct NPC and setting
- [ ] Unknown sceneId shows fallback "Unknown Scene"
- [ ] Map shows 5 nodes loaded from JSON asset
- [ ] Node positions match JSON x/yFraction values

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb