### PR TITLE
Phase 3: Onboarding, NPC seeding, companion recruitment, duel modifiers

### DIFF
--- a/app/src/main/kotlin/com/chimera/data/GameSessionManager.kt
+++ b/app/src/main/kotlin/com/chimera/data/GameSessionManager.kt
@@ -6,24 +6,30 @@ import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Holds the currently active save slot for the play session.
- * Injected into ViewModels that need to scope queries to a specific save.
- */
 @Singleton
 class GameSessionManager @Inject constructor() {
 
     private val _activeSlotId = MutableStateFlow<Long?>(null)
     val activeSlotId: StateFlow<Long?> = _activeSlotId.asStateFlow()
 
+    private var sessionStartTime: Long = 0L
+
     fun setActiveSlot(slotId: Long) {
         _activeSlotId.value = slotId
+        sessionStartTime = System.currentTimeMillis()
     }
 
     fun clearActiveSlot() {
         _activeSlotId.value = null
+        sessionStartTime = 0L
     }
 
     fun requireActiveSlotId(): Long =
         _activeSlotId.value ?: throw IllegalStateException("No active save slot")
+
+    /** Returns elapsed play time in seconds since slot was activated. */
+    fun getSessionPlaytimeSeconds(): Long {
+        if (sessionStartTime == 0L) return 0L
+        return (System.currentTimeMillis() - sessionStartTime) / 1000
+    }
 }

--- a/app/src/main/kotlin/com/chimera/data/NpcSeeder.kt
+++ b/app/src/main/kotlin/com/chimera/data/NpcSeeder.kt
@@ -1,0 +1,61 @@
+package com.chimera.data
+
+import android.content.Context
+import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterStateDao
+import com.chimera.database.entity.CharacterEntity
+import com.chimera.database.entity.CharacterStateEntity
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Serializable
+private data class NpcJson(
+    val id: String,
+    val name: String,
+    val title: String? = null,
+    val role: String,
+    val initialDisposition: Float = 0f,
+    val archetype: String? = null,
+    val portraitResName: String? = null
+)
+
+@Singleton
+class NpcSeeder @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val characterDao: CharacterDao,
+    private val characterStateDao: CharacterStateDao
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun seedNpcsForSlot(slotId: Long) {
+        val text = context.assets.open("npcs.json").bufferedReader().use { it.readText() }
+        val npcs = json.decodeFromString<List<NpcJson>>(text)
+
+        val characters = npcs.map { npc ->
+            CharacterEntity(
+                id = npc.id,
+                saveSlotId = slotId,
+                name = npc.name,
+                title = npc.title,
+                role = npc.role,
+                isPlayerCharacter = false,
+                portraitResName = npc.portraitResName
+            )
+        }
+        characterDao.upsertAll(characters)
+
+        npcs.forEach { npc ->
+            characterStateDao.upsert(
+                CharacterStateEntity(
+                    characterId = npc.id,
+                    saveSlotId = slotId,
+                    dispositionToPlayer = npc.initialDisposition,
+                    activeArchetype = npc.archetype
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chimera/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/chimera/ui/MainActivity.kt
@@ -5,36 +5,42 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.chimera.data.ChimeraPreferences
 import com.chimera.ui.navigation.ChimeraBottomBar
 import com.chimera.ui.navigation.ChimeraNavHost
 import com.chimera.ui.navigation.ChimeraRoutes
 import com.chimera.ui.navigation.TopLevelDestination
 import com.chimera.ui.theme.ChimeraTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var preferences: ChimeraPreferences
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             ChimeraTheme {
-                ChimeraApp()
+                ChimeraApp(preferences)
             }
         }
     }
 }
 
 @Composable
-fun ChimeraApp() {
+fun ChimeraApp(preferences: ChimeraPreferences) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
@@ -67,6 +73,7 @@ fun ChimeraApp() {
         ) { paddingValues ->
             ChimeraNavHost(
                 navController = navController,
+                preferences = preferences,
                 modifier = Modifier.padding(paddingValues)
             )
         }

--- a/app/src/main/kotlin/com/chimera/ui/navigation/ChimeraNavHost.kt
+++ b/app/src/main/kotlin/com/chimera/ui/navigation/ChimeraNavHost.kt
@@ -15,6 +15,9 @@ import com.chimera.ui.screens.home.HomeScreen
 import com.chimera.ui.screens.journal.JournalScreen
 import com.chimera.ui.screens.map.MapScreen
 import com.chimera.ui.screens.party.PartyScreen
+import androidx.compose.runtime.collectAsState
+import com.chimera.data.ChimeraPreferences
+import com.chimera.ui.screens.onboarding.OnboardingScreen
 import com.chimera.ui.screens.saveslot.SaveSlotSelectScreen
 import com.chimera.ui.screens.settings.SettingsScreen
 import com.chimera.ui.screens.splash.SplashScreen
@@ -22,6 +25,7 @@ import com.chimera.ui.screens.splash.SplashScreen
 @Composable
 fun ChimeraNavHost(
     navController: NavHostController,
+    preferences: ChimeraPreferences,
     modifier: Modifier = Modifier
 ) {
     NavHost(
@@ -30,10 +34,29 @@ fun ChimeraNavHost(
         modifier = modifier
     ) {
         composable(ChimeraRoutes.SPLASH) {
+            val settings by preferences.settings.collectAsState(
+                initial = com.chimera.data.AppSettings()
+            )
             SplashScreen(
                 onFinished = {
-                    navController.navigate(ChimeraRoutes.SAVE_SLOT_SELECT) {
+                    val dest = if (settings.tutorialComplete) {
+                        ChimeraRoutes.SAVE_SLOT_SELECT
+                    } else {
+                        ChimeraRoutes.ONBOARDING
+                    }
+                    navController.navigate(dest) {
                         popUpTo(ChimeraRoutes.SPLASH) { inclusive = true }
+                    }
+                }
+            )
+        }
+
+        composable(ChimeraRoutes.ONBOARDING) {
+            OnboardingScreen(
+                preferences = preferences,
+                onComplete = {
+                    navController.navigate(ChimeraRoutes.SAVE_SLOT_SELECT) {
+                        popUpTo(ChimeraRoutes.ONBOARDING) { inclusive = true }
                     }
                 }
             )

--- a/app/src/main/kotlin/com/chimera/ui/navigation/TopLevelDestination.kt
+++ b/app/src/main/kotlin/com/chimera/ui/navigation/TopLevelDestination.kt
@@ -22,6 +22,7 @@ enum class TopLevelDestination(
 
 object ChimeraRoutes {
     const val SPLASH = "splash"
+    const val ONBOARDING = "onboarding"
     const val SAVE_SLOT_SELECT = "save_slot_select"
     const val GAME_GRAPH = "game"
     const val HOME = "home"

--- a/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.chimera.ai.DialogueOrchestrator
 import com.chimera.data.GameSessionManager
 import com.chimera.data.SceneLoader
+import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.DialogueTurnDao
 import com.chimera.database.dao.JournalEntryDao
@@ -70,6 +71,7 @@ class DialogueSceneViewModel @Inject constructor(
     private val dialogueTurnDao: DialogueTurnDao,
     private val sceneInstanceDao: SceneInstanceDao,
     private val memoryShardDao: MemoryShardDao,
+    private val characterDao: CharacterDao,
     private val characterStateDao: CharacterStateDao,
     private val journalEntryDao: JournalEntryDao
 ) : ViewModel() {
@@ -204,7 +206,15 @@ class DialogueSceneViewModel @Inject constructor(
 
                 if (result.relationshipDelta != 0f) {
                     characterStateDao.adjustDisposition(contract.npcId, result.relationshipDelta)
-                    cachedCharState = null // invalidate cache after mutation
+                    cachedCharState = null
+                }
+
+                // Companion recruitment: promote NPC role to COMPANION
+                if (result.flags.contains("recruit_companion")) {
+                    val existing = characterDao.getById(contract.npcId)
+                    if (existing != null && existing.role != "COMPANION") {
+                        characterDao.upsert(existing.copy(role = "COMPANION"))
+                    }
                 }
 
                 val npcLine = DialogueLine(

--- a/app/src/main/kotlin/com/chimera/ui/screens/duel/DuelViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/duel/DuelViewModel.kt
@@ -2,20 +2,22 @@ package com.chimera.ui.screens.duel
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.entity.JournalEntryEntity
-import com.chimera.data.GameSessionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class DuelUiState(
     val playerName: String = "You",
-    val opponentName: String = "The Warden",
+    val opponentName: String = "Opponent",
     val round: Int = 0,
     val playerOmens: Int = 2,
     val opponentResolve: Int = 3,
@@ -28,37 +30,57 @@ data class DuelUiState(
 @HiltViewModel
 class DuelViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val characterDao: CharacterDao,
+    private val characterStateDao: CharacterStateDao,
     private val journalEntryDao: JournalEntryDao,
     private val gameSessionManager: GameSessionManager
 ) : ViewModel() {
 
     private val opponentId: String = savedStateHandle["opponentId"] ?: "warden"
-    private val opponentName: String = "The Warden" // TODO: look up from character DB
+    private var engine: DuelEngine? = null
 
-    private val engine = DuelEngine(
-        playerName = "You",
-        opponentName = opponentName,
-        opponentResolve = 3,
-        playerModifier = 0f // TODO: derive from prior dialogue choices
-    )
-
-    private val _uiState = MutableStateFlow(
-        DuelUiState(
-            opponentName = opponentName,
-            playerOmens = engine.getState().playerOmens,
-            opponentResolve = engine.getState().opponentResolve
-        )
-    )
+    private val _uiState = MutableStateFlow(DuelUiState())
     val uiState: StateFlow<DuelUiState> = _uiState.asStateFlow()
 
+    init {
+        initializeDuel()
+    }
+
+    private fun initializeDuel() {
+        viewModelScope.launch {
+            val character = characterDao.getById(opponentId)
+            val charState = characterStateDao.getByCharacterId(opponentId)
+            val opponentName = character?.let { "${it.name}${it.title?.let { t -> " $t" } ?: ""}" }
+                ?: "Unknown Opponent"
+
+            // Derive modifier from disposition: positive disposition = slight advantage
+            val disposition = charState?.dispositionToPlayer ?: 0f
+            val modifier = (disposition * 0.2f).coerceIn(-0.3f, 0.3f)
+
+            engine = DuelEngine(
+                playerName = "You",
+                opponentName = opponentName,
+                opponentResolve = 3,
+                playerModifier = modifier
+            )
+
+            _uiState.value = DuelUiState(
+                opponentName = opponentName,
+                playerOmens = engine!!.getState().playerOmens,
+                opponentResolve = engine!!.getState().opponentResolve
+            )
+        }
+    }
+
     fun selectStance(stance: DuelEngine.Stance) {
+        val eng = engine ?: return
         if (_uiState.value.isComplete) return
 
-        val result = engine.executeRound(stance)
-        val state = engine.getState()
+        val result = eng.executeRound(stance)
+        val state = eng.getState()
 
         _uiState.value = DuelUiState(
-            opponentName = opponentName,
+            opponentName = _uiState.value.opponentName,
             round = state.round,
             playerOmens = state.playerOmens,
             opponentResolve = state.opponentResolve,
@@ -77,15 +99,21 @@ class DuelViewModel @Inject constructor(
         viewModelScope.launch {
             val slotId = gameSessionManager.activeSlotId.value ?: return@launch
             val outcome = if (state.playerWon == true) "victorious" else "defeated"
+            val opponentName = _uiState.value.opponentName
             journalEntryDao.insert(
                 JournalEntryEntity(
                     saveSlotId = slotId,
                     title = "Ritual Duel: $opponentName",
-                    body = "The ritual duel with $opponentName concluded after ${state.round} rounds. You were $outcome. ${state.log.lastOrNull()?.narrative ?: ""}",
+                    body = "The ritual duel with $opponentName concluded after ${state.round} rounds. " +
+                        "You were $outcome. ${state.log.lastOrNull()?.narrative ?: ""}",
                     category = "story",
                     characterId = opponentId
                 )
             )
+
+            // Duel outcome affects disposition
+            val delta = if (state.playerWon == true) 0.1f else -0.05f
+            characterStateDao.adjustDisposition(opponentId, delta)
         }
     }
 }

--- a/app/src/main/kotlin/com/chimera/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/map/MapViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chimera.data.GameSessionManager
 import com.chimera.data.MapNodeLoader
+import com.chimera.database.dao.CharacterStateDao
+import kotlinx.serialization.json.Json
 import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.RumorPacketDao
 import com.chimera.database.dao.SceneInstanceDao
@@ -44,6 +46,7 @@ class MapViewModel @Inject constructor(
     private val sceneInstanceDao: SceneInstanceDao,
     private val rumorPacketDao: RumorPacketDao,
     private val factionStateDao: FactionStateDao,
+    private val characterStateDao: CharacterStateDao,
     private val mapNodeLoader: MapNodeLoader,
     gameSessionManager: GameSessionManager
 ) : ViewModel() {
@@ -68,13 +71,24 @@ class MapViewModel @Inject constructor(
                 val rumorsByLocation = rumors.groupBy { it.locationId }
                     .mapValues { (_, list) -> list.count { it.heatLevel > 0.3f } }
 
+                val json = Json { ignoreUnknownKeys = true }
                 val factionByLocation = factions.flatMap { faction ->
-                    // Simple mapping: faction controls locations listed in JSON
-                    listOf<Pair<String, String>>() // TODO: parse controlledLocationsJson
+                    try {
+                        val locations = json.decodeFromString<List<String>>(faction.controlledLocationsJson)
+                        locations.map { it to faction.factionName }
+                    } catch (_: Exception) {
+                        emptyList()
+                    }
                 }.toMap()
+
+                // Load character states for relationship-based unlock checks
+                val charStates = characterStateDao.observeBySlot(slotId)
+                val dispositions = mutableMapOf<String, Float>()
+                // Build a simple disposition lookup (using cached data from combine)
 
                 val nodes = baseNodes.map { node ->
                     val isCompleted = node.sceneId in completedScenes
+                    // Unlock if: node is default unlocked, OR a connected node is completed
                     val isUnlocked = node.isUnlocked || node.connectedTo.any { connId ->
                         baseNodes.find { it.id == connId }?.let { conn ->
                             conn.isUnlocked || conn.sceneId in completedScenes

--- a/app/src/main/kotlin/com/chimera/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/onboarding/OnboardingScreen.kt
@@ -1,0 +1,131 @@
+package com.chimera.ui.screens.onboarding
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.chimera.data.ChimeraPreferences
+import com.chimera.ui.theme.EmberGold
+import com.chimera.ui.theme.FadedBone
+import com.chimera.ui.theme.HollowCrimson
+import kotlinx.coroutines.launch
+
+@Composable
+fun OnboardingScreen(
+    preferences: ChimeraPreferences? = null,
+    onComplete: () -> Unit
+) {
+    var textScale by remember { mutableStateOf(1.0f) }
+    var reduceMotion by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            "CHIMERA",
+            style = MaterialTheme.typography.displayLarge,
+            color = EmberGold,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            "Ashes of the Hollow King",
+            style = MaterialTheme.typography.headlineSmall,
+            color = FadedBone,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            "Your words shape the world. NPCs remember your choices, " +
+            "reinterpret promises, and unlock or block future paths " +
+            "based on trust, fear, and faction pressure.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text("Accessibility", style = MaterialTheme.typography.titleMedium, color = EmberGold)
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text("Text Size: ${(textScale * 100).toInt()}%", style = MaterialTheme.typography.bodyMedium)
+                Slider(
+                    value = textScale,
+                    onValueChange = { textScale = it },
+                    valueRange = 0.8f..1.5f,
+                    colors = SliderDefaults.colors(thumbColor = EmberGold, activeTrackColor = HollowCrimson)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Reduce Motion", style = MaterialTheme.typography.bodyMedium)
+                    Switch(
+                        checked = reduceMotion,
+                        onCheckedChange = { reduceMotion = it },
+                        colors = SwitchDefaults.colors(checkedThumbColor = EmberGold, checkedTrackColor = HollowCrimson)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = {
+                scope.launch {
+                    preferences?.setTextScale(textScale)
+                    preferences?.setReduceMotion(reduceMotion)
+                    preferences?.setTutorialComplete(true)
+                    onComplete()
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(containerColor = HollowCrimson)
+        ) {
+            Text("Begin Your Journey", style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chimera/ui/screens/saveslot/SaveSlotSelectViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/saveslot/SaveSlotSelectViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chimera.data.GameSessionManager
+import com.chimera.data.NpcSeeder
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.entity.CharacterEntity
@@ -24,6 +25,7 @@ import javax.inject.Inject
 class SaveSlotSelectViewModel @Inject constructor(
     private val saveSlotDao: SaveSlotDao,
     private val characterDao: CharacterDao,
+    private val npcSeeder: NpcSeeder,
     private val gameSessionManager: GameSessionManager
 ) : ViewModel() {
 
@@ -61,6 +63,8 @@ class SaveSlotSelectViewModel @Inject constructor(
                         isPlayerCharacter = true
                     )
                 )
+                // Seed NPCs from assets for this save slot
+                npcSeeder.seedNpcsForSlot(slotId)
                 gameSessionManager.setActiveSlot(slotId)
                 onCreated(slotId)
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary

- **Onboarding**: First-launch screen with text scale + reduce motion settings, persists to DataStore, marks tutorialComplete, splash routes conditionally
- **NPC seeding**: NpcSeeder reads npcs.json on new game creation, inserts 5 NPCs with roles/dispositions/archetypes
- **Companion recruitment**: `recruit_companion` dialogue flag promotes NPC role to COMPANION
- **Duel modifiers**: DuelViewModel loads opponent from DB, derives modifier from disposition, outcome adjusts standing
- **Map faction parsing**: Replaces empty TODO with actual JSON parsing of controlledLocationsJson
- **Playtime tracking**: GameSessionManager tracks session start time

## Test plan

- [ ] First launch shows onboarding, subsequent launches skip to save slots
- [ ] New game creates 5 NPCs visible in Party screen
- [ ] Duel opponent name loads from database, not hardcoded
- [ ] Duel outcome adjusts NPC disposition
- [ ] Map nodes show faction names when factions control locations

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb