### PR TITLE
Phase 5: Full Act 1 content authoring

### DIFF
--- a/app/src/main/assets/act1_map.json
+++ b/app/src/main/assets/act1_map.json
@@ -23,7 +23,7 @@
     "name": "The Watchtower",
     "description": "A cracked spire overlooking the Hollow. Guards keep watch from its heights.",
     "sceneId": "watchtower_1",
-    "connectedTo": ["hollow_gate", "merchants_rest"],
+    "connectedTo": ["hollow_gate", "merchants_rest", "deserters_camp"],
     "xFraction": 0.7,
     "yFraction": 0.65
   },
@@ -32,7 +32,7 @@
     "name": "Merchant's Rest",
     "description": "A sheltered alcove where travelers barter goods and share rumors.",
     "sceneId": "merchants_1",
-    "connectedTo": ["outer_ruins", "watchtower", "deep_hollow"],
+    "connectedTo": ["outer_ruins", "watchtower", "deep_hollow", "broken_shrine"],
     "xFraction": 0.5,
     "yFraction": 0.4
   },
@@ -41,12 +41,42 @@
     "name": "The Deep Hollow",
     "description": "Darkness gathers where the King once held court. Few return unchanged.",
     "sceneId": "deep_hollow_1",
-    "connectedTo": ["outer_ruins", "merchants_rest"],
+    "connectedTo": ["outer_ruins", "merchants_rest", "hollow_approach"],
     "xFraction": 0.4,
     "yFraction": 0.15,
     "unlockRequirements": {
       "minDisposition": { "warden": 0.1 },
       "completedScenes": ["prologue_scene_1"]
+    }
+  },
+  {
+    "id": "deserters_camp",
+    "name": "Deserter's Camp",
+    "description": "A hidden camp behind the watchtower's shadow. Someone lives here in secret.",
+    "sceneId": "thorne_encounter",
+    "connectedTo": ["watchtower"],
+    "xFraction": 0.85,
+    "yFraction": 0.5
+  },
+  {
+    "id": "broken_shrine",
+    "name": "The Broken Shrine",
+    "description": "A corrupted altar where black incense burns. The air tastes of ash and prayer.",
+    "sceneId": "vessa_shrine",
+    "connectedTo": ["merchants_rest"],
+    "xFraction": 0.15,
+    "yFraction": 0.3
+  },
+  {
+    "id": "hollow_approach",
+    "name": "The Processional",
+    "description": "A crumbling hall of carved pillars leading to the throne room. The echoes grow louder.",
+    "sceneId": "hollow_approach",
+    "connectedTo": ["deep_hollow"],
+    "xFraction": 0.35,
+    "yFraction": 0.05,
+    "unlockRequirements": {
+      "completedScenes": ["deep_hollow_1"]
     }
   }
 ]

--- a/app/src/main/assets/act1_scenes.json
+++ b/app/src/main/assets/act1_scenes.json
@@ -6,7 +6,9 @@
     "npcName": "The Warden",
     "setting": "the crumbling gates of the Hollow",
     "stakes": "First contact with a gatekeeper who controls access to the ruins",
-    "maxTurns": 12
+    "maxTurns": 12,
+    "allowedReveals": ["hollow_history"],
+    "forbiddenTopics": ["king_identity"]
   },
   {
     "sceneId": "outer_ruins_1",
@@ -24,7 +26,9 @@
     "npcName": "Marcus the Guard",
     "setting": "atop a watchtower overlooking the Hollow",
     "stakes": "A suspicious guard questions your intentions and loyalty",
-    "maxTurns": 10
+    "maxTurns": 10,
+    "allowedReveals": ["garrison_movements"],
+    "forbiddenTopics": ["corruption_source"]
   },
   {
     "sceneId": "merchants_1",
@@ -33,7 +37,9 @@
     "npcName": "Aria the Scholar",
     "setting": "a sheltered alcove where travelers barter",
     "stakes": "A scholar seeks a research partner but hides a dangerous agenda",
-    "maxTurns": 12
+    "maxTurns": 12,
+    "allowedReveals": ["scholar_research"],
+    "forbiddenTopics": ["king_history"]
   },
   {
     "sceneId": "deep_hollow_1",
@@ -44,6 +50,59 @@
     "stakes": "A spectral echo offers power at a terrible cost",
     "maxTurns": 8,
     "allowedReveals": ["king_history", "corruption_source"],
+    "forbiddenTopics": ["escape_route"]
+  },
+  {
+    "sceneId": "elena_recruitment",
+    "sceneTitle": "The Merchant's Gambit",
+    "npcId": "elena",
+    "npcName": "Elena the Merchant",
+    "setting": "Elena's hidden cache behind the outer ruins",
+    "stakes": "Elena offers to join your cause if you prove your worth -- but her terms are steep",
+    "maxTurns": 10,
+    "allowedReveals": ["trade_routes", "supply_cache"]
+  },
+  {
+    "sceneId": "thorne_encounter",
+    "sceneTitle": "The Deserter's Camp",
+    "npcId": "thorne",
+    "npcName": "Thorne the Deserter",
+    "setting": "a makeshift camp hidden behind the watchtower's shadow",
+    "stakes": "A deserter from the Hollow garrison offers combat expertise but carries dangerous secrets",
+    "maxTurns": 12,
+    "allowedReveals": ["garrison_betrayal", "hollow_defenses"],
+    "forbiddenTopics": ["king_identity"]
+  },
+  {
+    "sceneId": "vessa_shrine",
+    "sceneTitle": "The Broken Shrine",
+    "npcId": "vessa",
+    "npcName": "Vessa the Hollow Priestess",
+    "setting": "a corrupted shrine where incense burns black",
+    "stakes": "A priestess tends a corrupted altar and speaks in riddles about the King's fall",
+    "maxTurns": 10,
+    "allowedReveals": ["corruption_source", "hollow_faith"],
+    "forbiddenTopics": ["garrison_movements"]
+  },
+  {
+    "sceneId": "warden_betrayal",
+    "sceneTitle": "The Warden's Secret",
+    "npcId": "warden",
+    "npcName": "The Warden",
+    "setting": "a hidden chamber beneath the gate mechanism",
+    "stakes": "The Warden reveals a terrible truth about why the Hollow was sealed",
+    "maxTurns": 10,
+    "allowedReveals": ["warden_secret", "king_identity"]
+  },
+  {
+    "sceneId": "hollow_approach",
+    "sceneTitle": "March to the Throne",
+    "npcId": "hollow_king",
+    "npcName": "The Hollow King's Echo",
+    "setting": "the crumbling processional hall leading to the throne room",
+    "stakes": "The King's echo tests your resolve one final time before granting passage",
+    "maxTurns": 8,
+    "allowedReveals": ["king_history", "corruption_source", "king_identity"],
     "forbiddenTopics": ["escape_route"]
   }
 ]

--- a/app/src/main/assets/npcs.json
+++ b/app/src/main/assets/npcs.json
@@ -43,5 +43,23 @@
     "initialDisposition": -0.5,
     "archetype": null,
     "portraitResName": null
+  },
+  {
+    "id": "thorne",
+    "name": "Thorne",
+    "title": "The Deserter",
+    "role": "COMPANION",
+    "initialDisposition": -0.1,
+    "archetype": "ESCALATION",
+    "portraitResName": null
+  },
+  {
+    "id": "vessa",
+    "name": "Vessa",
+    "title": "The Hollow Priestess",
+    "role": "NPC_NEUTRAL",
+    "initialDisposition": 0.0,
+    "archetype": "SHIFTING_THE_BURDEN",
+    "portraitResName": null
   }
 ]

--- a/app/src/main/kotlin/com/chimera/ai/FakeDialogueProvider.kt
+++ b/app/src/main/kotlin/com/chimera/ai/FakeDialogueProvider.kt
@@ -78,11 +78,15 @@ class FakeDialogueProvider @Inject constructor() : DialogueProvider {
                 flags = listOf("scene_ending"),
                 directorNotes = "Scene reaching max turns, wrap up"
             )
-            else -> DialogueTurnResult(
-                npcLine = getGenericResponse(disposition, turnCount),
-                emotion = if (disposition > 0.2f) "warm" else if (disposition < -0.2f) "cold" else "neutral",
-                relationshipDelta = 0.01f
-            )
+            else -> {
+                val line = getNpcVoicedResponse(contract.npcId, disposition, turnCount)
+                    ?: getGenericResponse(disposition, turnCount)
+                DialogueTurnResult(
+                    npcLine = line,
+                    emotion = if (disposition > 0.2f) "warm" else if (disposition < -0.2f) "cold" else "neutral",
+                    relationshipDelta = 0.01f
+                )
+            }
         }
     }
 
@@ -138,6 +142,149 @@ class FakeDialogueProvider @Inject constructor() : DialogueProvider {
         )
         return responses[turnCount % responses.size]
     }
+
+    private fun getNpcVoicedResponse(npcId: String, disposition: Float, turnCount: Int): String? {
+        val voices = npcVoices[npcId] ?: return null
+        val tier = when {
+            disposition > 0.3f -> voices.warm
+            disposition < -0.2f -> voices.cold
+            else -> voices.neutral
+        }
+        return tier[turnCount % tier.size]
+    }
+
+    private data class NpcVoice(
+        val warm: List<String>,
+        val cold: List<String>,
+        val neutral: List<String>
+    )
+
+    private val npcVoices = mapOf(
+        "warden" to NpcVoice(
+            warm = listOf(
+                "Duty brought me to this gate, but you give me reason to hope it wasn't in vain.",
+                "You carry yourself well. The Hollow respects strength -- and so do I.",
+                "I've watched the gate for years. Few earn my trust. You have."
+            ),
+            cold = listOf(
+                "The gate stays shut to those who cannot prove their worth. That includes you.",
+                "Duty demands I stand here. It does not demand I tolerate fools.",
+                "The gate remembers every soul that passed. It will remember you too -- briefly."
+            ),
+            neutral = listOf(
+                "The gate has stood longer than any of us. It will outlast us all.",
+                "I neither welcome nor refuse you. The Hollow decides who enters.",
+                "Duty is its own reward. Or so they told me when they posted me here."
+            )
+        ),
+        "elena" to NpcVoice(
+            warm = listOf(
+                "For you? A fair price. You've earned that much from me.",
+                "You strike a fair deal, and that's rare in the Hollow. I like working with you.",
+                "Business is business, but friendship? That's something I don't offer lightly. Consider it offered.",
+                "I've saved something special. Not for sale -- a gift. Don't make me regret it."
+            ),
+            cold = listOf(
+                "Everything has a price, and yours just went up.",
+                "I trade with anyone who pays. That doesn't mean I have to enjoy the company.",
+                "Coin talks. You don't. Pay or leave."
+            ),
+            neutral = listOf(
+                "The Hollow runs on barter. What do you bring to the table?",
+                "I've survived here longer than most soldiers. Commerce is its own kind of armor.",
+                "Supply and demand, stranger. Right now, I'm the supply, and you're the demand."
+            )
+        ),
+        "marcus" to NpcVoice(
+            warm = listOf(
+                "At ease. You've proven you're not the enemy. That's enough for now.",
+                "I don't say this often, but you fight clean. The garrison could use someone like you.",
+                "Stand with me on the wall sometime. I'll show you what we're really guarding against."
+            ),
+            cold = listOf(
+                "State your business or move along. I don't have time for games.",
+                "I've seen your kind before. All talk, no backbone when the shadows come.",
+                "One wrong move and I'll have you in irons. Don't test me.",
+                "The garrison doesn't tolerate threats. Neither do I."
+            ),
+            neutral = listOf(
+                "The watchtower sees everything. Including you.",
+                "I keep watch. That's my purpose. What's yours?",
+                "Another traveler. The Hollow collects them like stones in a river."
+            )
+        ),
+        "aria" to NpcVoice(
+            warm = listOf(
+                "Fascinating -- you understood that immediately. Most people stare blankly when I explain it.",
+                "The texts suggest a connection between the corruption and the King's crown. I need your help to prove it.",
+                "I rarely share my research, but you've earned access. Come, let me show you what I've found.",
+                "You ask the questions I've been afraid to ask myself. That takes courage."
+            ),
+            cold = listOf(
+                "Your ignorance is showing. Perhaps come back when you've read something. Anything.",
+                "I don't share my work with the unworthy. And you are decidedly unworthy.",
+                "The texts are clear on one point: knowledge belongs to those who seek it. You merely stumble."
+            ),
+            neutral = listOf(
+                "The archives hold more answers than any living person. I merely interpret.",
+                "Interesting. Not the answer I expected, but interesting nonetheless.",
+                "Every ruin tells a story. I'm still reading this one."
+            )
+        ),
+        "thorne" to NpcVoice(
+            warm = listOf(
+                "You don't know what it was like in the garrison. But you listen, and that counts for something.",
+                "I deserted because staying meant dying for a lie. You're the first person who didn't judge me for it.",
+                "Trust gets people killed. But I'm starting to think not trusting you might be worse."
+            ),
+            cold = listOf(
+                "Another righteous outsider. Save the lectures -- I've heard them all.",
+                "You want to know why I deserted? None of your damn business.",
+                "Keep your distance. I didn't survive this long by making friends."
+            ),
+            neutral = listOf(
+                "The garrison fell apart from the inside. Nobody talks about that.",
+                "I sleep with one eye open. The Hollow teaches you that, or it kills you.",
+                "Don't mistake my camp for hospitality. This is survival, not friendship."
+            )
+        ),
+        "vessa" to NpcVoice(
+            warm = listOf(
+                "The hollow speaks through stone, and today it speaks of you with warmth.",
+                "Faith is not comfort -- it is the courage to face what the darkness reveals. You have that courage.",
+                "The shrine remembers your kindness. So do I.",
+                "Come. Pray with me. Not to the old gods -- to whatever remains that is still good."
+            ),
+            cold = listOf(
+                "The corruption sees your heart, outsider. It does not like what it finds.",
+                "I tend this altar alone. Your presence profanes it.",
+                "Faith demands sacrifice. You bring only demands."
+            ),
+            neutral = listOf(
+                "The incense burns black because the hollow is sick. Not evil -- sick. There is a difference.",
+                "I was a priestess before the fall. Now I am... something else.",
+                "The old prayers don't work anymore. But I say them anyway."
+            )
+        ),
+        "hollow_king" to NpcVoice(
+            warm = listOf(
+                "You remind me of who I was before the crown consumed me. That is... dangerous.",
+                "Power is not given -- it is taken. But you... you might deserve what I offer.",
+                "Kneel not in submission, but in recognition of what you could become."
+            ),
+            cold = listOf(
+                "You dare stand before a king and offer nothing? Kneel or be forgotten.",
+                "I have waited centuries. Your defiance is a heartbeat compared to my patience.",
+                "The crown sees all who enter the Hollow. It found you... wanting.",
+                "Insignificant. The echoes of my reign will outlast your brief flame."
+            ),
+            neutral = listOf(
+                "I was a king once. Now I am an echo. But echoes still carry power.",
+                "The throne remembers every soul that sought it. Will you seek, or will you flee?",
+                "Time means nothing here. Your choices, however, mean everything."
+            )
+        )
+    )
 
     private fun getGenericResponse(disposition: Float, turnCount: Int): String {
         return when {

--- a/app/src/main/kotlin/com/chimera/data/NightEventProvider.kt
+++ b/app/src/main/kotlin/com/chimera/data/NightEventProvider.kt
@@ -60,15 +60,79 @@ class NightEventProvider @Inject constructor() {
                 NightEventChoice("Rest well", moraleDelta = 0.1f, outcome = "Everyone sleeps deeply. Morning comes with renewed purpose."),
                 NightEventChoice("Use the light to forage", moraleDelta = 0.03f, outcome = "You find useful herbs nearby. A small but welcome gain.")
             )
+        ),
+        NightEvent(
+            id = "wounded_stranger",
+            title = "The Wounded Stranger",
+            narrative = "A figure stumbles out of the darkness, bleeding from a wound that refuses to close. They collapse near the fire.",
+            choices = listOf(
+                NightEventChoice("Tend their wounds", moraleDelta = 0.06f, outcome = "The stranger's breathing steadies. By morning, they vanish -- leaving behind a small token of thanks."),
+                NightEventChoice("Question them first", moraleDelta = 0f, outcome = "They mutter about shadows with teeth before passing out. You learn nothing useful."),
+                NightEventChoice("Drive them away", moraleDelta = -0.06f, outcome = "The stranger staggers back into the dark. Their cries echo for a long time.")
+            )
+        ),
+        NightEvent(
+            id = "companion_confession",
+            title = "A Quiet Confession",
+            narrative = "A companion sits apart from the group, staring into the embers. Something weighs on them. They look like they want to talk.",
+            choices = listOf(
+                NightEventChoice("Sit beside them and listen", moraleDelta = 0.07f, outcome = "They share a memory from before the Hollow -- painful, but real. The bond between you deepens."),
+                NightEventChoice("Give them space", moraleDelta = 0.01f, outcome = "They nod when you look over, grateful for the privacy. Some wounds heal alone."),
+                NightEventChoice("Tell them to focus on the mission", moraleDelta = -0.04f, outcome = "They stiffen and turn away. The distance between you grows colder.")
+            )
+        ),
+        NightEvent(
+            id = "supplies_stolen",
+            title = "The Silent Thief",
+            narrative = "Dawn reveals that something raided the supplies overnight. Tracks lead toward the ruins -- small, clawed, deliberate.",
+            choices = listOf(
+                NightEventChoice("Track the thief", moraleDelta = 0.02f, outcome = "You follow the tracks to a nest of hollow-rats. You recover most of the supplies and find a curious artifact."),
+                NightEventChoice("Set a trap for tonight", moraleDelta = 0.04f, outcome = "The trap works. Whatever it was won't be back. The group sleeps easier."),
+                NightEventChoice("Accept the loss", moraleDelta = -0.05f, outcome = "Rations are shorter now. Nobody says anything, but the tension is palpable.")
+            )
+        ),
+        NightEvent(
+            id = "ancient_song",
+            title = "Song of the Stones",
+            narrative = "A melody drifts from the ruins -- hauntingly beautiful, wordless, ancient. It seems to come from the stones themselves.",
+            choices = listOf(
+                NightEventChoice("Follow the melody", moraleDelta = 0.03f, outcome = "The song leads to a carved alcove with faded murals of the Hollow King's court. You learn something about the past."),
+                NightEventChoice("Hum along", moraleDelta = 0.06f, outcome = "The melody harmonizes with your voice. For a moment, the Hollow feels less hostile. Everyone sleeps peacefully."),
+                NightEventChoice("Block it out", moraleDelta = -0.02f, outcome = "You stuff cloth in your ears. The song fades. But something feels lost.")
+            )
+        ),
+        NightEvent(
+            id = "watch_fire_dies",
+            title = "The Fire Goes Out",
+            narrative = "The watch-fire gutters and dies without warning. Not wind -- something else. The darkness presses close.",
+            choices = listOf(
+                NightEventChoice("Relight it immediately", moraleDelta = -0.01f, outcome = "The fire catches again, but the shadows seem thicker now. No one sleeps well."),
+                NightEventChoice("Wait in the dark", moraleDelta = -0.04f, outcome = "Minutes stretch into hours. When the fire finally reignites on its own, everyone is shaken."),
+                NightEventChoice("Gather the group close", moraleDelta = 0.03f, outcome = "You form a tight circle. Someone starts talking softly. By the time the fire returns, you've grown closer.")
+            )
+        ),
+        NightEvent(
+            id = "dream_vision",
+            title = "The King's Dream",
+            narrative = "You dream of a crowned figure on a throne of ash. He speaks without words, and you understand: 'Find what was taken. Return what was broken.'",
+            choices = listOf(
+                NightEventChoice("Try to speak back", moraleDelta = 0.02f, outcome = "The figure tilts its head. For a heartbeat, you see sorrow in hollow eyes. Then you wake."),
+                NightEventChoice("Reach for the crown", moraleDelta = -0.03f, outcome = "The crown burns. You wake gasping, your hand tingling. Power has a price."),
+                NightEventChoice("Turn away", moraleDelta = 0.01f, outcome = "The figure watches you go. You wake feeling strangely lighter, as if a burden was almost placed on you.")
+            )
         )
     )
 
+    private val tensionEvents = setOf("strange_noise", "companion_argument", "supplies_stolen", "watch_fire_dies")
+    private val hopeEvents = setOf("clear_skies", "companion_confession", "ancient_song")
+
     fun getRandomEvent(morale: Float): NightEvent {
-        // Weight negative events higher when morale is low
-        return if (morale < 0.3f && Random.nextFloat() < 0.6f) {
-            events.filter { it.id == "strange_noise" || it.id == "companion_argument" }.random()
-        } else {
-            events.random()
+        return when {
+            morale < 0.3f && Random.nextFloat() < 0.6f ->
+                events.filter { it.id in tensionEvents }.random()
+            morale > 0.7f && Random.nextFloat() < 0.4f ->
+                events.filter { it.id in hopeEvents }.random()
+            else -> events.random()
         }
     }
 }

--- a/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/dialogue/DialogueSceneViewModel.kt
@@ -10,6 +10,8 @@ import com.chimera.data.SceneLoader
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.SaveSlotDao
+import com.chimera.database.dao.VowDao
+import com.chimera.database.entity.VowEntity
 import com.chimera.database.dao.DialogueTurnDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
@@ -75,7 +77,8 @@ class DialogueSceneViewModel @Inject constructor(
     private val characterDao: CharacterDao,
     private val characterStateDao: CharacterStateDao,
     private val journalEntryDao: JournalEntryDao,
-    private val saveSlotDao: SaveSlotDao
+    private val saveSlotDao: SaveSlotDao,
+    private val vowDao: VowDao
 ) : ViewModel() {
 
     private val sceneId: String = savedStateHandle["sceneId"] ?: ""
@@ -263,6 +266,7 @@ class DialogueSceneViewModel @Inject constructor(
                         usedFallback = orchestrator.isFallbackActive
                     )
                     generateJournalEntry(slotId)
+                    generateVows(slotId)
                     // Persist accumulated playtime
                     val sessionSeconds = gameSessionManager.getSessionPlaytimeSeconds()
                     val slot = saveSlotDao.getById(slotId)
@@ -350,6 +354,41 @@ class DialogueSceneViewModel @Inject constructor(
                 )
             )
         }
+    }
+
+    private suspend fun generateVows(slotId: Long) {
+        val allFlags = turnResults.flatMap { it.flags }.toSet()
+        val disposition = cachedCharState?.dispositionToPlayer ?: 0f
+
+        // Authored vow triggers based on scene + flags + disposition
+        val vows = mutableListOf<VowEntity>()
+
+        if (contract.npcId == "warden" && disposition > 0.3f && allFlags.contains("scene_ending")) {
+            vows.add(VowEntity(
+                saveSlotId = slotId,
+                description = "Protect the Hollow from those who would exploit it",
+                swornTo = "warden",
+                sceneIdOrigin = sceneId
+            ))
+        }
+        if (contract.npcId == "aria" && allFlags.contains("scene_ending")) {
+            vows.add(VowEntity(
+                saveSlotId = slotId,
+                description = "Find the source of the corruption in the deep ruins",
+                swornTo = "aria",
+                sceneIdOrigin = sceneId
+            ))
+        }
+        if (contract.sceneId == "elena_recruitment" && allFlags.contains("recruit_companion")) {
+            vows.add(VowEntity(
+                saveSlotId = slotId,
+                description = "Return what was taken from Elena's hidden cache",
+                swornTo = "elena",
+                sceneIdOrigin = sceneId
+            ))
+        }
+
+        vows.forEach { vowDao.insert(it) }
     }
 
     private suspend fun persistTurn(speakerId: String, text: String, emotion: String) {

--- a/app/src/main/kotlin/com/chimera/ui/screens/duel/DuelEngine.kt
+++ b/app/src/main/kotlin/com/chimera/ui/screens/duel/DuelEngine.kt
@@ -100,7 +100,8 @@ class DuelEngine(
     }
 
     private fun buildNarrative(player: Stance, opponent: Stance, outcome: RoundOutcome, round: Int): String {
-        return when (outcome) {
+        val escalation = getEscalationPrefix(round)
+        val core = when (outcome) {
             RoundOutcome.WIN -> when (player) {
                 Stance.STRIKE -> "Your strike cuts through ${opponentName}'s feint. Their resolve wavers."
                 Stance.WARD -> "You hold firm against ${opponentName}'s blow. The impact rebounds."
@@ -112,6 +113,20 @@ class DuelEngine(
                 Stance.FEINT -> "${opponentName}'s feint draws you out of position."
             }
             RoundOutcome.DRAW -> "You mirror each other's stance. The ritual holds its breath."
+        }
+        return if (escalation.isNotEmpty()) "$escalation $core" else core
+    }
+
+    private fun getEscalationPrefix(round: Int): String {
+        return when (round) {
+            1 -> ""
+            2 -> "You test each other's measure."
+            3 -> "The ritual crackles with building energy."
+            4 -> "Sweat beads on both brows. The air grows heavy."
+            5 -> "The stones beneath your feet hum with power."
+            6 -> "One of you will break. The ritual demands it."
+            7 -> "This is the final exchange. Everything rides on this moment."
+            else -> ""
         }
     }
 }


### PR DESCRIPTION
## Summary

Full Act 1 content authoring to meet execution set spec:

- **7 NPCs** (was 5): Added Thorne the Deserter and Vessa the Hollow Priestess
- **3 companions** (was 1): Aria, Elena (recruitable), Thorne (recruitable)
- **10 scenes** (was 5): 5 new scenes with distinct NPCs, settings, stakes
- **8 map nodes** (was 5): 3 new locations with connection graph
- **7 NPC voices** (~80 authored lines): Distinct personality per NPC with warm/cold/neutral tiers
- **10 night events** (was 4): 6 new events with morale-weighted selection
- **Duel escalation**: Round-by-round tension prefixes
- **3 authored vows**: Triggered by scene completion + disposition thresholds
- **Reveal constraints**: Distributed across 7 scenes for narrative progression

## Test plan

- [ ] All 10 scenes loadable from map
- [ ] 7 NPCs seeded on new game creation
- [ ] Each NPC speaks in their distinct voice (not generic fallback)
- [ ] 10 night events cycle with morale weighting
- [ ] Duel narratives include escalation prefixes after round 1
- [ ] Completing Warden scene with high disposition creates "Protect the Hollow" vow
- [ ] Completing Aria scene creates "Find corruption source" vow

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb