### PR TITLE
Phase B+C: Act 2 content, quest system, NPC personas

### DIFF
--- a/app/src/main/assets/act2_map.json
+++ b/app/src/main/assets/act2_map.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "ashen_gate",
+    "name": "The Ashen Gate",
+    "description": "A massive iron gate fused shut by ancient fire. A forge glows beside it.",
+    "sceneId": "ashen_gate",
+    "connectedTo": ["hollow_approach", "ash_market", "memorial_field"],
+    "xFraction": 0.5,
+    "yFraction": 0.9
+  },
+  {
+    "id": "ash_market",
+    "name": "Cinder Market",
+    "description": "A bazaar of scorched wagons and salvaged stone. Commerce persists even here.",
+    "sceneId": "ash_market",
+    "connectedTo": ["ashen_gate", "ember_sanctum", "reforged_camp"],
+    "xFraction": 0.25,
+    "yFraction": 0.7
+  },
+  {
+    "id": "memorial_field",
+    "name": "Field of Names",
+    "description": "Rusted weapons planted blade-first in ash, each marking a fallen soldier.",
+    "sceneId": "memorial_field",
+    "connectedTo": ["ashen_gate", "ruined_library"],
+    "xFraction": 0.75,
+    "yFraction": 0.65
+  },
+  {
+    "id": "ember_sanctum",
+    "name": "Ember Sanctum",
+    "description": "An underground cathedral where the walls glow with trapped firelight.",
+    "sceneId": "ember_sanctum",
+    "connectedTo": ["ash_market", "reforged_camp"],
+    "xFraction": 0.15,
+    "yFraction": 0.45
+  },
+  {
+    "id": "reforged_camp",
+    "name": "Reforged Enclave",
+    "description": "A fortified camp of the Reforged faction, rebuilt from ash and defiance.",
+    "sceneId": "reforged_camp",
+    "connectedTo": ["ash_market", "ember_sanctum", "ashen_throne"],
+    "xFraction": 0.4,
+    "yFraction": 0.35
+  },
+  {
+    "id": "ruined_library",
+    "name": "The Burned Archive",
+    "description": "Charred shelves hold fragments of knowledge. Someone has been reading here.",
+    "sceneId": "aria_confession",
+    "connectedTo": ["memorial_field", "deep_forge"],
+    "xFraction": 0.8,
+    "yFraction": 0.4
+  },
+  {
+    "id": "deep_forge",
+    "name": "The Deep Forge",
+    "description": "Where heat bends reality and old oaths echo. The forgemaster's domain.",
+    "sceneId": "kael_loyalty",
+    "connectedTo": ["ruined_library", "ashen_throne"],
+    "xFraction": 0.65,
+    "yFraction": 0.2
+  },
+  {
+    "id": "ashen_throne",
+    "name": "The Ashen Throne",
+    "description": "A mirror of the Hollow Throne, built from scorched bone and regret.",
+    "sceneId": "act2_climax",
+    "connectedTo": ["reforged_camp", "deep_forge"],
+    "xFraction": 0.5,
+    "yFraction": 0.05,
+    "unlockRequirements": {
+      "completedScenes": ["reforged_camp", "kael_loyalty"]
+    }
+  }
+]

--- a/app/src/main/assets/act2_npcs.json
+++ b/app/src/main/assets/act2_npcs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "kael",
+    "name": "Kael",
+    "title": "The Forgemaster",
+    "role": "NPC_NEUTRAL",
+    "initialDisposition": 0.0,
+    "archetype": "GROWTH_AND_UNDERINVESTMENT",
+    "portraitResName": null
+  },
+  {
+    "id": "seren",
+    "name": "Seren",
+    "title": "Voice of the Reforged",
+    "role": "FACTION_LEADER",
+    "initialDisposition": -0.1,
+    "archetype": "SHIFTING_THE_BURDEN",
+    "portraitResName": null
+  }
+]

--- a/app/src/main/assets/act2_scenes.json
+++ b/app/src/main/assets/act2_scenes.json
@@ -1,0 +1,107 @@
+[
+  {
+    "sceneId": "ashen_gate",
+    "sceneTitle": "The Ashen Gate",
+    "npcId": "kael",
+    "npcName": "Kael the Forgemaster",
+    "setting": "a massive iron gate fused shut by ancient fire, with a forge still glowing beside it",
+    "stakes": "The only passage to the Ashen Reaches is sealed. The forgemaster knows how to open it -- for a price",
+    "maxTurns": 10,
+    "allowedReveals": ["forge_history", "reforged_origins"],
+    "forbiddenTopics": ["king_identity"]
+  },
+  {
+    "sceneId": "ash_market",
+    "sceneTitle": "The Cinder Market",
+    "npcId": "elena",
+    "npcName": "Elena the Merchant",
+    "setting": "a makeshift bazaar built from scorched wagons and salvaged stone, deeper in the Reaches",
+    "stakes": "Elena has expanded her trade network here but faces threats from a rival faction",
+    "maxTurns": 10,
+    "allowedReveals": ["trade_routes", "reforged_movements"]
+  },
+  {
+    "sceneId": "memorial_field",
+    "sceneTitle": "The Field of Names",
+    "npcId": "thorne",
+    "npcName": "Thorne the Deserter",
+    "setting": "a field of rusted weapons planted blade-first in ash, each marking a fallen soldier",
+    "stakes": "Thorne confronts ghosts of his former comrades and must decide whether to honor or abandon their memory",
+    "maxTurns": 12,
+    "allowedReveals": ["garrison_betrayal", "deserter_truth"],
+    "forbiddenTopics": ["escape_route"]
+  },
+  {
+    "sceneId": "ember_sanctum",
+    "sceneTitle": "The Ember Sanctum",
+    "npcId": "vessa",
+    "npcName": "Vessa the Hollow Priestess",
+    "setting": "an underground cathedral where the walls glow with trapped firelight",
+    "stakes": "Vessa discovers the corruption has a source -- and it is not what anyone expected",
+    "maxTurns": 10,
+    "allowedReveals": ["corruption_source", "hollow_faith", "reforged_prophecy"]
+  },
+  {
+    "sceneId": "reforged_camp",
+    "sceneTitle": "The Reforged Enclave",
+    "npcId": "seren",
+    "npcName": "Seren of the Reforged",
+    "setting": "a fortified camp of former Hollow King subjects who rejected his rule and rebuilt in the ash",
+    "stakes": "The Reforged faction offers alliance but demands proof of commitment against the Echo",
+    "maxTurns": 12,
+    "allowedReveals": ["reforged_origins", "reforged_prophecy"]
+  },
+  {
+    "sceneId": "aria_confession",
+    "sceneTitle": "The Scholar's Confession",
+    "npcId": "aria",
+    "npcName": "Aria the Scholar",
+    "setting": "a ruined library where Aria has been secretly researching the King's crown",
+    "stakes": "Aria reveals her true agenda -- she seeks the crown for herself, believing she can control it",
+    "maxTurns": 10,
+    "allowedReveals": ["scholar_research", "crown_nature"],
+    "forbiddenTopics": ["reforged_prophecy"]
+  },
+  {
+    "sceneId": "kael_loyalty",
+    "sceneTitle": "The Forgemaster's Test",
+    "npcId": "kael",
+    "npcName": "Kael the Forgemaster",
+    "setting": "deep within the forge, where the heat bends reality and old oaths still echo",
+    "stakes": "Kael offers to reforge a weapon against the Echo, but the cost is a piece of the player's memory",
+    "maxTurns": 8,
+    "allowedReveals": ["forge_history", "crown_nature"]
+  },
+  {
+    "sceneId": "echo_confrontation",
+    "sceneTitle": "The Echo Speaks",
+    "npcId": "hollow_king",
+    "npcName": "The Hollow King's Echo",
+    "setting": "the border between the Hollow and the Reaches, where reality thins to a whisper",
+    "stakes": "The Echo appears outside its domain for the first time, desperate and furious",
+    "maxTurns": 8,
+    "allowedReveals": ["king_history", "king_identity", "corruption_source"],
+    "forbiddenTopics": ["escape_route"]
+  },
+  {
+    "sceneId": "seren_alliance",
+    "sceneTitle": "The Pact of Ashes",
+    "npcId": "seren",
+    "npcName": "Seren of the Reforged",
+    "setting": "the Reforged war table, lit by embers from the original Hollow forge",
+    "stakes": "Final alliance negotiation -- the Reforged will march or refuse based on the player's choices",
+    "maxTurns": 10,
+    "allowedReveals": ["reforged_prophecy", "crown_nature"]
+  },
+  {
+    "sceneId": "act2_climax",
+    "sceneTitle": "The Crown's Choice",
+    "npcId": "hollow_king",
+    "npcName": "The Hollow King's Echo",
+    "setting": "the Ashen Throne, a mirror of the Hollow Throne built from scorched bone and regret",
+    "stakes": "The final confrontation of Act 2 -- destroy the crown, wear it, or offer it to the Reforged",
+    "maxTurns": 8,
+    "allowedReveals": ["king_identity", "crown_nature", "corruption_source", "reforged_prophecy"],
+    "forbiddenTopics": []
+  }
+]

--- a/app/src/main/assets/npc_personas.json
+++ b/app/src/main/assets/npc_personas.json
@@ -1,0 +1,47 @@
+{
+  "warden": {
+    "voice": "Formal, terse, speaks in obligations and duty. Short sentences. Military bearing softened by weariness.",
+    "backstory": "Has guarded the Hollow Gate for years. Knows why it was sealed but won't say unless trusted. Carries guilt about something he allowed to happen.",
+    "speechPatterns": ["Duty demands...", "The gate remembers...", "I neither welcome nor refuse..."]
+  },
+  "elena": {
+    "voice": "Pragmatic, transactional, uses merchant metaphors. Warm and generous when trusted, sharp when crossed.",
+    "backstory": "A survivor who turned to trade after the Hollow fell. Hides supply caches throughout the ruins. Wants stability more than power.",
+    "speechPatterns": ["Everything has a price...", "You strike a fair deal...", "Supply and demand, stranger..."]
+  },
+  "marcus": {
+    "voice": "Suspicious, military cadence, aggressive. Questions motives before listening. Respects strength and directness.",
+    "backstory": "A garrison guard who never left his post. Watches the watchtower alone. Distrusts outsiders but desperately wants allies.",
+    "speechPatterns": ["State your business...", "I've seen your kind...", "The watchtower sees everything..."]
+  },
+  "aria": {
+    "voice": "Intellectual, curious, evasive about motives. Uses scholarly language. Hides ambition behind academic detachment.",
+    "backstory": "A scholar who came to study the Hollow King's fall. Secretly believes the crown can be controlled and wants it for herself.",
+    "speechPatterns": ["Fascinating...", "The texts suggest...", "Every ruin tells a story..."]
+  },
+  "thorne": {
+    "voice": "Bitter, haunted, blunt. Short declarative sentences. Gallows humor. Talks about survival, not heroism.",
+    "backstory": "Deserted the garrison when he discovered the truth about why they were really posted there. Lives with shame and anger.",
+    "speechPatterns": ["Trust gets people killed...", "You don't know what it was like...", "I sleep with one eye open..."]
+  },
+  "vessa": {
+    "voice": "Mystical, cryptic, compassionate. Speaks in metaphors about stone and faith. Gentle but unflinching about hard truths.",
+    "backstory": "A priestess who stayed when others fled. Tends a corrupted altar, believing the Hollow itself is sick, not evil.",
+    "speechPatterns": ["The hollow speaks through stone...", "Faith is not comfort...", "The old prayers don't work anymore..."]
+  },
+  "hollow_king": {
+    "voice": "Imperious, ancient, tempting. Speaks with certainty and sorrow. Offers power while revealing its cost. Regal syntax.",
+    "backstory": "An echo of the king who built the Hollow, now trapped between existence and oblivion. The crown corrupted him slowly.",
+    "speechPatterns": ["Kneel...", "Power is not given, it is taken...", "I was a king once..."]
+  },
+  "kael": {
+    "voice": "Gruff, practical, speaks through craft metaphors. Values work over words. Judges people by what they make, not what they say.",
+    "backstory": "The last forgemaster of the Hollow, who sealed the Ashen Gate himself. Knows how to unmake what he built -- but fears the consequences.",
+    "speechPatterns": ["Iron remembers...", "You can't forge what you won't face...", "The fire doesn't care about your reasons..."]
+  },
+  "seren": {
+    "voice": "Charismatic, revolutionary, measured anger. Speaks for a community. Uses 'we' more than 'I'. Pragmatic idealist.",
+    "backstory": "Founded the Reforged from refugees who escaped the Hollow King's rule. Believes in building something new, not restoring what was.",
+    "speechPatterns": ["We chose ash over chains...", "The Reforged don't kneel...", "Build forward, not backward..."]
+  }
+}

--- a/app/src/main/kotlin/com/chimera/data/SceneLoader.kt
+++ b/app/src/main/kotlin/com/chimera/data/SceneLoader.kt
@@ -14,6 +14,8 @@ class SceneLoader @Inject constructor(
     private val json = Json { ignoreUnknownKeys = true }
     private var cache: Map<String, SceneContract>? = null
 
+    private val sceneFiles = listOf("act1_scenes.json", "act2_scenes.json")
+
     fun getScene(sceneId: String): SceneContract? {
         return loadAll()[sceneId]
     }
@@ -22,12 +24,29 @@ class SceneLoader @Inject constructor(
         return loadAll().values.toList()
     }
 
+    fun getScenesByAct(act: String): List<SceneContract> {
+        val prefix = when (act) {
+            "act1", "prologue" -> "act1_scenes.json"
+            "act2" -> "act2_scenes.json"
+            else -> return emptyList()
+        }
+        return loadFromFile(prefix)
+    }
+
     private fun loadAll(): Map<String, SceneContract> {
         cache?.let { return it }
-        val text = context.assets.open("act1_scenes.json").bufferedReader().use { it.readText() }
-        val scenes = json.decodeFromString<List<SceneContract>>(text)
-        val map = scenes.associateBy { it.sceneId }
+        val allScenes = sceneFiles.flatMap { loadFromFile(it) }
+        val map = allScenes.associateBy { it.sceneId }
         cache = map
         return map
+    }
+
+    private fun loadFromFile(filename: String): List<SceneContract> {
+        return try {
+            val text = context.assets.open(filename).bufferedReader().use { it.readText() }
+            json.decodeFromString<List<SceneContract>>(text)
+        } catch (_: Exception) {
+            emptyList()
+        }
     }
 }

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -13,6 +13,7 @@ import com.chimera.database.dao.DialogueTurnDao
 import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
+import com.chimera.database.dao.QuestDao
 import com.chimera.database.dao.RumorPacketDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
@@ -23,6 +24,7 @@ import com.chimera.database.entity.DialogueTurnEntity
 import com.chimera.database.entity.FactionStateEntity
 import com.chimera.database.entity.JournalEntryEntity
 import com.chimera.database.entity.MemoryShardEntity
+import com.chimera.database.entity.QuestEntity
 import com.chimera.database.entity.RumorPacketEntity
 import com.chimera.database.entity.SaveSlotEntity
 import com.chimera.database.entity.SceneInstanceEntity
@@ -39,9 +41,10 @@ import com.chimera.database.entity.VowEntity
         JournalEntryEntity::class,
         VowEntity::class,
         RumorPacketEntity::class,
-        FactionStateEntity::class
+        FactionStateEntity::class,
+        QuestEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -55,6 +58,7 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     abstract fun sceneInstanceDao(): SceneInstanceDao
     abstract fun journalEntryDao(): JournalEntryDao
     abstract fun vowDao(): VowDao
+    abstract fun questDao(): QuestDao
     abstract fun rumorPacketDao(): RumorPacketDao
     abstract fun factionStateDao(): FactionStateDao
 

--- a/core-database/src/main/kotlin/com/chimera/database/dao/QuestDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/QuestDao.kt
@@ -1,0 +1,32 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.chimera.database.entity.QuestEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface QuestDao {
+
+    @Query("SELECT * FROM quests WHERE save_slot_id = :slotId ORDER BY created_at DESC")
+    fun observeAll(slotId: Long): Flow<List<QuestEntity>>
+
+    @Query("SELECT * FROM quests WHERE save_slot_id = :slotId AND status = 'active' ORDER BY created_at DESC")
+    fun observeActive(slotId: Long): Flow<List<QuestEntity>>
+
+    @Insert
+    suspend fun insert(quest: QuestEntity): Long
+
+    @Query("UPDATE quests SET current_step = current_step + 1 WHERE id = :id AND current_step < total_steps")
+    suspend fun advanceStep(id: Long)
+
+    @Query("UPDATE quests SET status = 'completed', completed_at = :completedAt WHERE id = :id")
+    suspend fun complete(id: Long, completedAt: Long = System.currentTimeMillis())
+
+    @Query("UPDATE quests SET status = 'failed' WHERE id = :id")
+    suspend fun fail(id: Long)
+
+    @Query("SELECT COUNT(*) FROM quests WHERE save_slot_id = :slotId AND status = 'active'")
+    fun observeActiveCount(slotId: Long): Flow<Int>
+}

--- a/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
@@ -8,6 +8,7 @@ import com.chimera.database.dao.DialogueTurnDao
 import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
+import com.chimera.database.dao.QuestDao
 import com.chimera.database.dao.RumorPacketDao
 import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
@@ -39,4 +40,5 @@ object DatabaseModule {
     @Provides fun provideVowDao(db: ChimeraGameDatabase): VowDao = db.vowDao()
     @Provides fun provideRumorPacketDao(db: ChimeraGameDatabase): RumorPacketDao = db.rumorPacketDao()
     @Provides fun provideFactionStateDao(db: ChimeraGameDatabase): FactionStateDao = db.factionStateDao()
+    @Provides fun provideQuestDao(db: ChimeraGameDatabase): QuestDao = db.questDao()
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/QuestEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/QuestEntity.kt
@@ -1,0 +1,51 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "quests",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id")]
+)
+data class QuestEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    val title: String,
+
+    val description: String,
+
+    @ColumnInfo(name = "total_steps")
+    val totalSteps: Int,
+
+    @ColumnInfo(name = "current_step")
+    val currentStep: Int = 0,
+
+    val status: String = "active", // active, completed, failed
+
+    @ColumnInfo(name = "source_scene_id")
+    val sourceSceneId: String? = null,
+
+    @ColumnInfo(name = "source_npc_id")
+    val sourceNpcId: String? = null,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+
+    @ColumnInfo(name = "completed_at")
+    val completedAt: Long? = null
+)


### PR DESCRIPTION
## Summary

- **Act 2 "The Ashen Reaches"**: 10 new scenes, 8 map nodes, 2 new NPCs (Kael, Seren), new faction "The Reforged"
- **NPC personas**: 9 detailed personality descriptions with voice, backstory, speech patterns for AI prompt consistency
- **Quest system**: QuestEntity with multi-step progression, QuestDao with step/complete/fail tracking, DB v5
- **Multi-act loading**: SceneLoader reads from both act1 and act2 JSON files with graceful fallback
- **Narrative arc**: Act 2 builds on Act 1 reveals -- crown nature, faction alliances, companion loyalty tests, climactic choice

## Test plan

- [ ] Act 2 scenes loadable via SceneLoader.getScene()
- [ ] Act 2 map nodes display when Act 2 is reached
- [ ] QuestDao insert/advance/complete operations work
- [ ] NPC personas file loads without errors
- [ ] SceneLoader returns combined Act 1 + Act 2 scenes from getAllScenes()
- [ ] Missing act files handled gracefully (empty list, no crash)

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb