### PR TITLE
Sprint pack final: CampRepository, EnvironmentConfig, forbidden topic validation

### DIFF
--- a/app/src/main/kotlin/com/chimera/ai/DialogueResponseParser.kt
+++ b/app/src/main/kotlin/com/chimera/ai/DialogueResponseParser.kt
@@ -2,6 +2,7 @@ package com.chimera.ai
 
 import android.util.Log
 import com.chimera.model.DialogueTurnResult
+import com.chimera.model.SceneContract
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.float
@@ -15,6 +16,29 @@ import kotlinx.serialization.json.jsonPrimitive
 object DialogueResponseParser {
 
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    /**
+     * Parse and validate against scene contract constraints.
+     * Strips forbidden topic mentions from the NPC line.
+     */
+    fun parseAndValidate(raw: String, contract: SceneContract): DialogueTurnResult? {
+        val result = parse(raw) ?: return null
+        if (contract.forbiddenTopics.isEmpty()) return result
+
+        val lower = result.npcLine.lowercase()
+        val violated = contract.forbiddenTopics.any { topic ->
+            lower.contains(topic.replace("_", " "))
+        }
+        return if (violated) {
+            Log.w("DialogueParser", "Forbidden topic detected, sanitizing response")
+            result.copy(
+                npcLine = "I... cannot speak of that. Ask me something else.",
+                directorNotes = "Original response violated forbidden topics: ${contract.forbiddenTopics}"
+            )
+        } else {
+            result
+        }
+    }
 
     /**
      * Parse a raw AI response string into a DialogueTurnResult.

--- a/app/src/main/kotlin/com/chimera/data/EnvironmentConfig.kt
+++ b/app/src/main/kotlin/com/chimera/data/EnvironmentConfig.kt
@@ -1,0 +1,43 @@
+package com.chimera.data
+
+import com.chimera.BuildConfig
+
+/**
+ * Provider mode determines how the AI dialogue system operates.
+ */
+enum class ProviderMode {
+    /** Use cloud AI with automatic fallback to authored templates. */
+    AUTO,
+    /** Use only authored templates (offline mode). */
+    FAKE,
+    /** Use only Gemini provider (for testing). */
+    GEMINI_ONLY,
+    /** Use only Groq provider (for testing). */
+    GROQ_ONLY
+}
+
+/**
+ * Environment configuration derived from build variant.
+ * Set via product flavors in build.gradle.kts (mock/dev/prod).
+ */
+object EnvironmentConfig {
+    val providerMode: ProviderMode = try {
+        ProviderMode.valueOf(BuildConfig.PROVIDER_MODE)
+    } catch (_: Exception) {
+        ProviderMode.AUTO
+    }
+
+    val apiBaseUrl: String = BuildConfig.API_BASE_URL
+
+    val isDemoMode: Boolean = try {
+        BuildConfig.DEMO_MODE
+    } catch (_: Exception) {
+        false
+    }
+
+    val isDebug: Boolean = BuildConfig.DEBUG
+
+    val geminiApiKey: String = BuildConfig.GEMINI_API_KEY
+    val groqApiKey: String = BuildConfig.GROQ_API_KEY
+    val openRouterApiKey: String = BuildConfig.OPENROUTER_API_KEY
+}

--- a/app/src/main/kotlin/com/chimera/data/repository/CampRepository.kt
+++ b/app/src/main/kotlin/com/chimera/data/repository/CampRepository.kt
@@ -1,0 +1,55 @@
+package com.chimera.data.repository
+
+import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterStateDao
+import com.chimera.database.dao.VowDao
+import com.chimera.database.entity.VowEntity
+import com.chimera.database.mapper.toModel
+import com.chimera.model.CharacterState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class CampSummary(
+    val morale: Float,
+    val companionCount: Int,
+    val activeVowCount: Int,
+    val avgDisposition: Float
+)
+
+@Singleton
+class CampRepository @Inject constructor(
+    private val characterDao: CharacterDao,
+    private val characterStateDao: CharacterStateDao,
+    private val vowDao: VowDao
+) {
+    fun observeCampSummary(slotId: Long): Flow<CampSummary> =
+        combine(
+            characterDao.observeCompanions(slotId),
+            characterStateDao.observeBySlot(slotId),
+            vowDao.observeActive(slotId)
+        ) { companions, states, vows ->
+            val dispositions = states
+                .filter { s -> companions.any { c -> c.id == s.characterId } }
+                .map { it.dispositionToPlayer }
+            val avg = dispositions.takeIf { it.isNotEmpty() }?.average()?.toFloat() ?: 0f
+            val morale = ((avg + 1f) / 2f).coerceIn(0f, 1f)
+
+            CampSummary(
+                morale = morale,
+                companionCount = companions.size,
+                activeVowCount = vows.size,
+                avgDisposition = avg
+            )
+        }
+
+    fun observeActiveVows(slotId: Long): Flow<List<VowEntity>> =
+        vowDao.observeActive(slotId)
+
+    fun observeCompanionStates(slotId: Long): Flow<List<CharacterState>> =
+        characterStateDao.observeBySlot(slotId).map { states ->
+            states.map { it.toModel() }
+        }
+}

--- a/app/src/test/kotlin/com/chimera/ai/DialogueResponseParserTest.kt
+++ b/app/src/test/kotlin/com/chimera/ai/DialogueResponseParserTest.kt
@@ -1,5 +1,6 @@
 package com.chimera.ai
 
+import com.chimera.model.SceneContract
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -109,5 +110,45 @@ class DialogueResponseParserTest {
         val result = DialogueResponseParser.parse(json)
         assertNotNull(result)
         assertTrue(result!!.memoryCandidates.size <= 3)
+    }
+
+    // --- SceneContract validation tests ---
+
+    private val contractWithForbidden = SceneContract(
+        sceneId = "test", sceneTitle = "Test", npcId = "npc", npcName = "NPC",
+        setting = "room", forbiddenTopics = listOf("escape_route", "king_identity")
+    )
+
+    @Test
+    fun `parseAndValidate passes clean response`() {
+        val json = """{"npcLine":"The hollow is ancient.","emotion":"neutral","relationshipDelta":0.0,"flags":[],"memoryCandidates":[]}"""
+        val result = DialogueResponseParser.parseAndValidate(json, contractWithForbidden)
+        assertNotNull(result)
+        assertEquals("The hollow is ancient.", result!!.npcLine)
+    }
+
+    @Test
+    fun `parseAndValidate strips forbidden topic mention`() {
+        val json = """{"npcLine":"Let me tell you about the escape route out of here.","emotion":"neutral","relationshipDelta":0.0,"flags":[],"memoryCandidates":[]}"""
+        val result = DialogueResponseParser.parseAndValidate(json, contractWithForbidden)
+        assertNotNull(result)
+        assertTrue(result!!.npcLine.contains("cannot speak"))
+    }
+
+    @Test
+    fun `parseAndValidate detects underscore-separated forbidden topics`() {
+        val json = """{"npcLine":"The king identity is known to few.","emotion":"neutral","relationshipDelta":0.0,"flags":[],"memoryCandidates":[]}"""
+        val result = DialogueResponseParser.parseAndValidate(json, contractWithForbidden)
+        assertNotNull(result)
+        assertTrue(result!!.npcLine.contains("cannot speak"))
+    }
+
+    @Test
+    fun `parseAndValidate with no forbidden topics passes everything`() {
+        val noForbidden = contractWithForbidden.copy(forbiddenTopics = emptyList())
+        val json = """{"npcLine":"Talk about escape route freely.","emotion":"neutral","relationshipDelta":0.0,"flags":[],"memoryCandidates":[]}"""
+        val result = DialogueResponseParser.parseAndValidate(json, noForbidden)
+        assertNotNull(result)
+        assertEquals("Talk about escape route freely.", result!!.npcLine)
     }
 }


### PR DESCRIPTION
## Summary

Final sprint pack compliance items:

- **CampRepository**: Morale derivation, active vows, companion state observation
- **EnvironmentConfig**: ProviderMode enum (AUTO/FAKE/GEMINI_ONLY/GROQ_ONLY), BuildConfig reader for product flavors
- **Forbidden topic validation**: `DialogueResponseParser.parseAndValidate()` checks NPC response against `SceneContract.forbiddenTopics`, sanitizes violations
- **4 new tests** (94 total): forbidden topic detection, clean pass-through, underscore normalization, empty forbidden list

## Test plan

- [ ] `./gradlew test` passes all 94 tests
- [ ] CampRepository.observeCampSummary() returns valid morale
- [ ] EnvironmentConfig.providerMode reads from BuildConfig correctly
- [ ] parseAndValidate strips responses mentioning forbidden topics

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb