### PR TITLE
Domain use case layer: 7 use cases per sprint pack spec

### DIFF
--- a/app/src/main/kotlin/com/chimera/domain/usecase/ApplyRelationshipDeltaUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/ApplyRelationshipDeltaUseCase.kt
@@ -1,0 +1,43 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.CharacterRepository
+import com.chimera.database.dao.JournalEntryDao
+import com.chimera.database.entity.JournalEntryEntity
+import javax.inject.Inject
+import kotlin.math.abs
+
+class ApplyRelationshipDeltaUseCase @Inject constructor(
+    private val characterRepository: CharacterRepository,
+    private val journalEntryDao: JournalEntryDao
+) {
+    /**
+     * Apply a relationship delta and optionally create a journal entry
+     * if the change is significant enough.
+     */
+    suspend operator fun invoke(
+        slotId: Long,
+        characterId: String,
+        characterName: String,
+        delta: Float,
+        context: String = ""
+    ) {
+        characterRepository.adjustDisposition(characterId, delta)
+
+        if (abs(delta) >= JOURNAL_THRESHOLD) {
+            val direction = if (delta > 0) "warmed to" else "grown colder toward"
+            journalEntryDao.insert(
+                JournalEntryEntity(
+                    saveSlotId = slotId,
+                    title = "$characterName's Regard",
+                    body = "$characterName has $direction you${if (context.isNotBlank()) " after $context" else ""}.",
+                    category = "companion",
+                    characterId = characterId
+                )
+            )
+        }
+    }
+
+    companion object {
+        const val JOURNAL_THRESHOLD = 0.1f
+    }
+}

--- a/app/src/main/kotlin/com/chimera/domain/usecase/CreateSaveSlotUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/CreateSaveSlotUseCase.kt
@@ -1,0 +1,19 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.GameSessionManager
+import com.chimera.data.NpcSeeder
+import com.chimera.data.repository.SaveRepository
+import javax.inject.Inject
+
+class CreateSaveSlotUseCase @Inject constructor(
+    private val saveRepository: SaveRepository,
+    private val npcSeeder: NpcSeeder,
+    private val gameSessionManager: GameSessionManager
+) {
+    suspend operator fun invoke(slotIndex: Int, playerName: String): Long {
+        val slotId = saveRepository.createSlot(slotIndex, playerName)
+        npcSeeder.seedNpcsForSlot(slotId)
+        gameSessionManager.setActiveSlot(slotId)
+        return slotId
+    }
+}

--- a/app/src/main/kotlin/com/chimera/domain/usecase/GenerateSceneSummaryUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/GenerateSceneSummaryUseCase.kt
@@ -1,0 +1,50 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.JournalRepository
+import com.chimera.database.entity.JournalEntryEntity
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.SceneContract
+import javax.inject.Inject
+
+class GenerateSceneSummaryUseCase @Inject constructor(
+    private val journalRepository: JournalRepository
+) {
+    suspend operator fun invoke(
+        slotId: Long,
+        contract: SceneContract,
+        turnResults: List<DialogueTurnResult>
+    ) {
+        val turnCount = turnResults.size
+        val summary = if (turnCount > 1) {
+            "Spoke with ${contract.npcName} at ${contract.setting}. " +
+            "The conversation spanned $turnCount exchanges."
+        } else {
+            "A brief encounter with ${contract.npcName}."
+        }
+
+        // Story entry
+        journalRepository.insertEntry(
+            JournalEntryEntity(
+                saveSlotId = slotId,
+                title = contract.sceneTitle,
+                body = summary,
+                category = "story",
+                sceneId = contract.sceneId,
+                characterId = contract.npcId
+            )
+        )
+
+        // Companion entry on recruitment
+        if (turnResults.any { it.flags.contains("recruit_companion") }) {
+            journalRepository.insertEntry(
+                JournalEntryEntity(
+                    saveSlotId = slotId,
+                    title = "${contract.npcName} Joins",
+                    body = "${contract.npcName} has agreed to join your cause.",
+                    category = "companion",
+                    characterId = contract.npcId
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/chimera/domain/usecase/LoadHomeStateUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/LoadHomeStateUseCase.kt
@@ -1,0 +1,43 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.GameSessionManager
+import com.chimera.data.repository.JournalRepository
+import com.chimera.data.repository.SaveRepository
+import com.chimera.model.SaveSlot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+data class HomeState(
+    val playerName: String = "",
+    val chapterTag: String = "prologue",
+    val activeVowCount: Int = 0,
+    val isLoading: Boolean = true
+)
+
+class LoadHomeStateUseCase @Inject constructor(
+    private val saveRepository: SaveRepository,
+    private val journalRepository: JournalRepository,
+    private val gameSessionManager: GameSessionManager
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    operator fun invoke(): Flow<HomeState> =
+        gameSessionManager.activeSlotId.flatMapLatest { slotId ->
+            if (slotId == null) return@flatMapLatest flowOf(HomeState(isLoading = false))
+            combine(
+                saveRepository.observeAllSlots(),
+                journalRepository.observeActiveVows(slotId)
+            ) { slots, vows ->
+                val slot = slots.find { it.id == slotId }
+                HomeState(
+                    playerName = slot?.playerName ?: "",
+                    chapterTag = slot?.chapterTag ?: "prologue",
+                    activeVowCount = vows.size,
+                    isLoading = false
+                )
+            }
+        }
+}

--- a/app/src/main/kotlin/com/chimera/domain/usecase/ResolveCampNightUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/ResolveCampNightUseCase.kt
@@ -1,0 +1,36 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.NightEvent
+import com.chimera.data.NightEventChoice
+import com.chimera.data.NightEventProvider
+import com.chimera.data.RumorService
+import com.chimera.data.repository.CampRepository
+import javax.inject.Inject
+
+data class CampNightOutcome(
+    val event: NightEvent,
+    val chosenOption: NightEventChoice,
+    val outcome: String,
+    val moraleChange: Float
+)
+
+class ResolveCampNightUseCase @Inject constructor(
+    private val nightEventProvider: NightEventProvider,
+    private val campRepository: CampRepository,
+    private val rumorService: RumorService
+) {
+    fun selectEvent(morale: Float): NightEvent =
+        nightEventProvider.getRandomEvent(morale)
+
+    suspend fun resolve(slotId: Long, event: NightEvent, choice: NightEventChoice): CampNightOutcome {
+        // Advance day: decay rumors
+        rumorService.advanceDay(slotId)
+
+        return CampNightOutcome(
+            event = event,
+            chosenOption = choice,
+            outcome = choice.outcome,
+            moraleChange = choice.moraleDelta
+        )
+    }
+}

--- a/app/src/main/kotlin/com/chimera/domain/usecase/StartSceneUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/StartSceneUseCase.kt
@@ -1,0 +1,65 @@
+package com.chimera.domain.usecase
+
+import com.chimera.ai.DialogueOrchestrator
+import com.chimera.data.SceneLoader
+import com.chimera.data.repository.CharacterRepository
+import com.chimera.data.repository.DialogueRepository
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.MemoryShard
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
+import javax.inject.Inject
+
+data class SceneInitResult(
+    val contract: SceneContract,
+    val openingTurn: DialogueTurnResult,
+    val intents: List<String>,
+    val characterState: CharacterState,
+    val recentMemories: List<MemoryShard>,
+    val sceneInstanceId: Long,
+    val isFallback: Boolean
+)
+
+class StartSceneUseCase @Inject constructor(
+    private val sceneLoader: SceneLoader,
+    private val dialogueRepository: DialogueRepository,
+    private val characterRepository: CharacterRepository,
+    private val orchestrator: DialogueOrchestrator
+) {
+    suspend operator fun invoke(slotId: Long, sceneId: String): SceneInitResult {
+        val contract = sceneLoader.getScene(sceneId) ?: SceneContract(
+            sceneId = sceneId,
+            sceneTitle = "Unknown Scene",
+            npcId = "unknown",
+            npcName = "Stranger",
+            setting = "an unfamiliar place"
+        )
+
+        val instanceId = dialogueRepository.createSceneInstance(slotId, sceneId, contract.npcId)
+
+        val charState = characterRepository.getCharacterState(contract.npcId)
+            ?: CharacterState(characterId = contract.npcId, saveSlotId = slotId)
+
+        val memories = dialogueRepository.getRecentMemories(slotId, contract.npcId, 5)
+
+        val openingInput = PlayerInput(text = "[Scene begins]", isQuickIntent = true)
+        val openingTurn = orchestrator.generateTurn(
+            contract, openingInput, charState, memories, emptyList()
+        )
+
+        dialogueRepository.persistTurn(slotId, sceneId, contract.npcId, openingTurn.npcLine, openingTurn.emotion)
+
+        val intents = orchestrator.generateIntents(contract, charState, listOf(openingTurn))
+
+        return SceneInitResult(
+            contract = contract,
+            openingTurn = openingTurn,
+            intents = intents,
+            characterState = charState,
+            recentMemories = memories,
+            sceneInstanceId = instanceId,
+            isFallback = orchestrator.isFallbackActive
+        )
+    }
+}

--- a/app/src/main/kotlin/com/chimera/domain/usecase/SubmitDialogueTurnUseCase.kt
+++ b/app/src/main/kotlin/com/chimera/domain/usecase/SubmitDialogueTurnUseCase.kt
@@ -1,0 +1,77 @@
+package com.chimera.domain.usecase
+
+import com.chimera.ai.DialogueOrchestrator
+import com.chimera.data.repository.CharacterRepository
+import com.chimera.data.repository.DialogueRepository
+import com.chimera.database.entity.MemoryShardEntity
+import com.chimera.model.CharacterState
+import com.chimera.model.DialogueTurnResult
+import com.chimera.model.MemoryShard
+import com.chimera.model.PlayerInput
+import com.chimera.model.SceneContract
+import javax.inject.Inject
+
+data class TurnOutcome(
+    val result: DialogueTurnResult,
+    val isFallback: Boolean,
+    val updatedDisposition: Float?
+)
+
+class SubmitDialogueTurnUseCase @Inject constructor(
+    private val orchestrator: DialogueOrchestrator,
+    private val dialogueRepository: DialogueRepository,
+    private val characterRepository: CharacterRepository
+) {
+    suspend operator fun invoke(
+        slotId: Long,
+        sceneId: String,
+        contract: SceneContract,
+        playerInput: PlayerInput,
+        characterState: CharacterState,
+        recentMemories: List<MemoryShard>,
+        turnHistory: List<DialogueTurnResult>
+    ): TurnOutcome {
+        // Persist player turn
+        dialogueRepository.persistTurn(slotId, sceneId, "player", playerInput.text, "")
+
+        // Generate NPC response
+        val result = orchestrator.generateTurn(
+            contract, playerInput, characterState, recentMemories, turnHistory
+        )
+
+        // Persist NPC turn
+        dialogueRepository.persistTurn(slotId, sceneId, contract.npcId, result.npcLine, result.emotion)
+
+        // Batch insert memory candidates
+        if (result.memoryCandidates.isNotEmpty()) {
+            val shards = result.memoryCandidates.map { summary ->
+                MemoryShardEntity(
+                    saveSlotId = slotId,
+                    sceneId = sceneId,
+                    characterId = contract.npcId,
+                    summary = summary,
+                    importanceScore = 0.6f
+                )
+            }
+            dialogueRepository.insertMemoryShards(shards)
+        }
+
+        // Apply relationship delta
+        var updatedDisposition: Float? = null
+        if (result.relationshipDelta != 0f) {
+            characterRepository.adjustDisposition(contract.npcId, result.relationshipDelta)
+            updatedDisposition = characterRepository.getCharacterState(contract.npcId)?.dispositionToPlayer
+        }
+
+        // Handle companion recruitment
+        if (result.flags.contains("recruit_companion")) {
+            characterRepository.promoteToCompanion(contract.npcId)
+        }
+
+        return TurnOutcome(
+            result = result,
+            isFallback = orchestrator.isFallbackActive,
+            updatedDisposition = updatedDisposition
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Domain use case layer per sprint pack spec -- 7 use cases encapsulating business logic:

- **CreateSaveSlotUseCase**: slot creation + NPC seeding + session activation
- **LoadHomeStateUseCase**: reactive Flow combining save data + vow count
- **StartSceneUseCase**: contract loading, scene instance, opening turn generation
- **SubmitDialogueTurnUseCase**: turn persistence, memory shards, disposition, recruitment
- **ApplyRelationshipDeltaUseCase**: disposition + journal entry on significant change
- **GenerateSceneSummaryUseCase**: story + companion journal entries from scene data
- **ResolveCampNightUseCase**: morale-weighted event selection, day advancement

## Test plan

- [ ] Use cases injectable via Hilt
- [ ] CreateSaveSlotUseCase returns valid slot ID and seeds NPCs
- [ ] SubmitDialogueTurnUseCase persists turns and adjusts disposition
- [ ] ResolveCampNightUseCase triggers rumor decay

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb