### PR TITLE
Sprint pack 39/39: detekt, memory dedupe, rumor fields, DB v6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 :app             Android application: Compose UI, navigation, screens, AI provider layer, DI
 ```
 
-The `android/` directory contains a legacy DialogGPT service module (excluded from build, reference only).
+The `android/` directory contains a legacy DialogGPT service module (excluded from build, reference only). **The root-level `:app` module is the canonical Android entrypoint.** Do not treat `android/` as an active build target.
 
 ### Key Components
 
-1. **Room Database** (`core-database/.../ChimeraGameDatabase.kt`): v5 schema with 11 entities: SaveSlots, Characters, CharacterStates, DialogueTurns, MemoryShards, SceneInstances, JournalEntries, Vows, RumorPackets, FactionStates, Quests
+1. **Room Database** (`core-database/.../ChimeraGameDatabase.kt`): v6 schema with 11 entities: SaveSlots, Characters, CharacterStates, DialogueTurns, MemoryShards, SceneInstances, JournalEntries, Vows, RumorPackets, FactionStates, Quests
 2. **RelationshipArchetypeEngine** (`core-database/.../engine/RelationshipArchetypeEngine.kt`): Systems-thinking feedback loops driving NPC disposition changes (thread-safe, bounded delayed feedback)
 3. **DialogueOrchestrator** (`app/.../ai/DialogueOrchestrator.kt`): AI provider abstraction with automatic fallback to FakeDialogueProvider, output validation (clamp deltas, bound memory candidates)
 3b. **ProviderRouter** (`app/.../ai/ProviderRouter.kt`): Ordered chain of free AI providers (Gemini → Groq → OpenRouter) with auto-failover

--- a/app/src/main/kotlin/com/chimera/data/repository/DialogueRepository.kt
+++ b/app/src/main/kotlin/com/chimera/data/repository/DialogueRepository.kt
@@ -45,7 +45,12 @@ class DialogueRepository @Inject constructor(
         memoryShardDao.getTopMemories(slotId, characterId, limit).map { it.toModel() }
 
     suspend fun insertMemoryShards(shards: List<MemoryShardEntity>) {
-        if (shards.isNotEmpty()) memoryShardDao.insertAll(shards)
+        if (shards.isEmpty()) return
+        // Deduplicate: skip shards with identical summary for the same character in the same slot
+        val deduped = shards.filter { shard ->
+            memoryShardDao.countDuplicates(shard.saveSlotId, shard.characterId, shard.summary) == 0
+        }
+        if (deduped.isNotEmpty()) memoryShardDao.insertAll(deduped)
     }
 
     suspend fun getCompletedSceneIds(slotId: Long): Set<String> =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.detekt)
 }

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -44,7 +44,7 @@ import com.chimera.database.entity.VowEntity
         FactionStateEntity::class,
         QuestEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 @TypeConverters(Converters::class)

--- a/core-database/src/main/kotlin/com/chimera/database/dao/MemoryShardDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/MemoryShardDao.kt
@@ -31,4 +31,10 @@ interface MemoryShardDao {
 
     @Query("SELECT COUNT(*) FROM memory_shards WHERE save_slot_id = :slotId")
     suspend fun countBySlot(slotId: Long): Int
+
+    @Query(
+        "SELECT COUNT(*) FROM memory_shards " +
+        "WHERE save_slot_id = :slotId AND character_id = :characterId AND summary = :summary"
+    )
+    suspend fun countDuplicates(slotId: Long, characterId: String, summary: String): Int
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/RumorPacketEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/RumorPacketEntity.kt
@@ -38,6 +38,14 @@ data class RumorPacketEntity(
     @ColumnInfo(name = "heat_level")
     val heatLevel: Float = 0.5f, // 0.0 = cold, 1.0 = hot
 
+    @ColumnInfo(name = "truth_level")
+    val truthLevel: Float = 0.5f, // 0.0 = false, 1.0 = confirmed true
+
+    val sentiment: String = "neutral", // positive, negative, neutral, threatening
+
+    @ColumnInfo(name = "spread_score")
+    val spreadScore: Float = 0.0f, // how far the rumor has spread (0.0..1.0)
+
     @ColumnInfo(name = "is_verified")
     val isVerified: Boolean = false,
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,37 @@
+build:
+  maxIssues: 0
+
+complexity:
+  LongMethod:
+    threshold: 60
+  LongParameterList:
+    functionThreshold: 8
+    constructorThreshold: 10
+  CyclomaticComplexMethod:
+    threshold: 15
+
+naming:
+  FunctionNaming:
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
+  TopLevelPropertyNaming:
+    constantPattern: '[A-Z][A-Za-z0-9]*'
+  MatchingDeclarationName:
+    active: false
+
+style:
+  MagicNumber:
+    active: false
+  MaxLineLength:
+    maxLineLength: 140
+  WildcardImport:
+    active: false
+  ReturnCount:
+    max: 4
+  UnusedPrivateMember:
+    active: true
+
+potential-bugs:
+  UnsafeCast:
+    active: true
+  UselessPostfixExpression:
+    active: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,11 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 androidx-test-ext = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 
+# Static Analysis
+detekt = "1.23.4"
+
 [plugins]
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

Closes the last 2 partial sprint pack tickets to achieve 39/39 compliance:

- **CHI-0005**: Detekt static analysis plugin + config (thresholds tuned for project)
- **CHI-3003**: Memory shard deduplication (countDuplicates query + DialogueRepository filter)
- **CHI-5001**: Rumor packet schema completed (truthLevel, sentiment, spreadScore fields)
- **CHI-0001**: CLAUDE.md explicitly documents `:app` as canonical Android entrypoint
- **DB v6**: Schema updated for new rumor fields

## Test plan

- [ ] `./gradlew detekt` runs without crashing (may report issues on first run)
- [ ] Memory shards with identical summaries are not duplicated
- [ ] RumorPacketEntity includes truthLevel, sentiment, spreadScore fields

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb