### PR TITLE
Play Store beta release: signing, AAB bundle, metadata, crash hooks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -121,13 +121,23 @@ jobs:
       run: chmod +x gradlew
 
     - name: Build Release APK
-      run: ./gradlew assembleRelease
+      run: ./gradlew assembleProdRelease
+
+    - name: Build Release AAB (Play Store)
+      run: ./gradlew bundleProdRelease
 
     - name: Upload Release APK
       uses: actions/upload-artifact@v4
       with:
         name: chimera-release-apk
-        path: app/build/outputs/apk/release/*.apk
+        path: app/build/outputs/apk/prodRelease/*.apk
+        retention-days: 90
+
+    - name: Upload Release AAB
+      uses: actions/upload-artifact@v4
+      with:
+        name: chimera-release-aab
+        path: app/build/outputs/bundle/prodRelease/*.aab
         retention-days: 90
 
   build-demo:
@@ -179,14 +189,20 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: chimera-release-apk
-        path: release-apk/
+        path: release-artifacts/
+
+    - name: Download Release AAB
+      uses: actions/download-artifact@v4
+      with:
+        name: chimera-release-aab
+        path: release-artifacts/
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        files: release-apk/*.apk
+        files: release-artifacts/*
         generate_release_notes: true
         body: |
-          Chimera: Ashes of the Hollow King
+          Chimera: Ashes of the Hollow King - Beta Release
 
-          Download the APK to begin your journey into the Hollow.
+          Download the APK for direct install, or use the AAB for Play Store upload.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.chimera.ashes"
         minSdk = 24
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0.0-alpha"
+        versionCode = (project.findProperty("VERSION_CODE") as? String)?.toIntOrNull() ?: 1
+        versionName = (project.findProperty("VERSION_NAME") as? String) ?: "1.0.0-beta"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -49,13 +49,30 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = project.findProperty("KEYSTORE_PATH") as? String
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+                storePassword = project.findProperty("KEYSTORE_PASSWORD") as? String ?: ""
+                keyAlias = project.findProperty("KEY_ALIAS") as? String ?: ""
+                keyPassword = project.findProperty("KEY_PASSWORD") as? String ?: ""
+            }
+        }
+    }
+
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            val releaseSigningConfig = signingConfigs.findByName("release")
+            if (releaseSigningConfig?.storeFile != null) {
+                signingConfig = releaseSigningConfig
+            }
         }
         debug {
             isDebuggable = true
@@ -93,6 +110,18 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+
+    bundle {
+        language {
+            enableSplit = true
+        }
+        density {
+            enableSplit = true
+        }
+        abi {
+            enableSplit = true
         }
     }
 }

--- a/app/src/main/kotlin/com/chimera/data/CrashReporter.kt
+++ b/app/src/main/kotlin/com/chimera/data/CrashReporter.kt
@@ -1,0 +1,39 @@
+package com.chimera.data
+
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Crash monitoring placeholder. Replace with Firebase Crashlytics or Sentry
+ * when ready for production.
+ *
+ * To integrate Firebase Crashlytics:
+ * 1. Add google-services.json to app/
+ * 2. Add Firebase BOM + Crashlytics dependencies
+ * 3. Replace log() with FirebaseCrashlytics.getInstance().recordException()
+ * 4. Replace setUser() with FirebaseCrashlytics.getInstance().setUserId()
+ */
+@Singleton
+class CrashReporter @Inject constructor() {
+
+    fun initialize() {
+        Log.d(TAG, "CrashReporter initialized (placeholder -- no remote reporting)")
+    }
+
+    fun log(throwable: Throwable, context: String = "") {
+        Log.e(TAG, "Crash: $context", throwable)
+    }
+
+    fun log(message: String) {
+        Log.w(TAG, "Event: $message")
+    }
+
+    fun setUser(slotId: Long) {
+        Log.d(TAG, "Active user: slot $slotId")
+    }
+
+    companion object {
+        private const val TAG = "CrashReporter"
+    }
+}

--- a/app/src/main/play/listings/en-US/full-description.txt
+++ b/app/src/main/play/listings/en-US/full-description.txt
@@ -1,0 +1,30 @@
+Chimera: Ashes of the Hollow King is a narrative RPG where every conversation matters.
+
+YOUR WORDS SHAPE THE WORLD
+Speak freely with NPCs who remember your promises, reinterpret your actions, and unlock or block future paths based on trust, fear, and faction pressure. No dialogue trees -- real consequences.
+
+AI-ASSISTED DIALOGUE
+NPCs respond with authored personality when offline, and with AI-enhanced dialogue when connected. The game works fully offline with rich, hand-crafted responses.
+
+COMPANION RELATIONSHIPS
+Recruit companions whose loyalty evolves through your choices. Each companion has a personal arc that unlocks through deepening trust.
+
+RITUAL DUELS
+Settle disputes through stance-based ritual combat. Your prior dialogue choices grant advantages -- or disadvantages.
+
+EXPLORE THE HOLLOW
+Navigate a node-based world map across two story acts. Discover rumors, track faction influence, and uncover the truth behind the Hollow King's fall.
+
+CAMP & JOURNAL
+Rest at camp, assign companion duties, resolve night events. Your journal tracks every story beat, rumor, vow, and companion interaction.
+
+FEATURES
+- 20 authored scenes across 2 acts
+- 9 unique NPCs with distinct personalities
+- 3 recruitable companions with loyalty arcs
+- Stance-based ritual duel system
+- Persistent vow and quest tracking
+- Morale-driven camp system with night events
+- Faction influence and rumor heat mechanics
+- Works fully offline with authored fallback dialogue
+- Dark fantasy aesthetic with serif typography

--- a/app/src/main/play/listings/en-US/short-description.txt
+++ b/app/src/main/play/listings/en-US/short-description.txt
@@ -1,0 +1,1 @@
+A narrative RPG where your words shape the world. NPCs remember, adapt, and evolve.

--- a/app/src/main/play/listings/en-US/title.txt
+++ b/app/src/main/play/listings/en-US/title.txt
@@ -1,0 +1,1 @@
+Chimera: Ashes of the Hollow King

--- a/app/src/main/play/release-notes/en-US/default.txt
+++ b/app/src/main/play/release-notes/en-US/default.txt
@@ -1,0 +1,10 @@
+Beta Release v1.0.0-beta
+
+- Complete Act 1 and Act 2 story content
+- AI-powered dialogue with free-tier providers (Gemini, Groq, OpenRouter)
+- Save system with 3 slots
+- Companion recruitment and loyalty system
+- Ritual duel combat
+- Camp with duty assignments and night events
+- Journal with story, rumor, vow, and companion tracking
+- Node-based world map with faction markers and rumor heat


### PR DESCRIPTION
## Summary

Play Store beta release configuration:

- **App signing**: Release signing from gradle properties, minification + shrink enabled
- **AAB bundle**: Split by language/density/ABI for optimal download size
- **Version management**: Configurable via VERSION_CODE/VERSION_NAME properties (default 1.0.0-beta)
- **Play Console metadata**: Title, short description, full description, release notes in `app/src/main/play/`
- **Crash monitoring**: CrashReporter placeholder ready for Firebase Crashlytics or Sentry
- **CI/CD**: Release job builds APK + AAB, both included in GitHub Releases

## Test plan

- [ ] `./gradlew assembleProdRelease` produces APK
- [ ] `./gradlew bundleProdRelease` produces AAB
- [ ] Play Store listing files present in `app/src/main/play/`
- [ ] CrashReporter injectable via Hilt
- [ ] CI release job uploads both APK and AAB artifacts

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb