### PR TITLE
Integration tests: 123 total (29 new, target 120+)

### DIFF
--- a/app/src/test/kotlin/com/chimera/data/DutyAssignmentTest.kt
+++ b/app/src/test/kotlin/com/chimera/data/DutyAssignmentTest.kt
@@ -1,0 +1,44 @@
+package com.chimera.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DutyAssignmentTest {
+
+    @Test
+    fun `guard duty has negative morale effect`() {
+        assertTrue(DutyType.GUARD.moraleEffect < 0f)
+    }
+
+    @Test
+    fun `forage duty has positive morale effect`() {
+        assertTrue(DutyType.FORAGE.moraleEffect > 0f)
+    }
+
+    @Test
+    fun `rest duty has highest morale effect`() {
+        assertTrue(DutyType.REST.moraleEffect > DutyType.FORAGE.moraleEffect)
+    }
+
+    @Test
+    fun `all duty types have labels`() {
+        DutyType.values().forEach { duty ->
+            assertTrue(duty.label.isNotBlank())
+            assertTrue(duty.description.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `duty assignment defaults to no duty`() {
+        val assignment = DutyAssignment("comp1", "Elena")
+        assertEquals(null, assignment.duty)
+    }
+
+    @Test
+    fun `duty assignment with duty set`() {
+        val assignment = DutyAssignment("comp1", "Elena", DutyType.GUARD)
+        assertEquals(DutyType.GUARD, assignment.duty)
+        assertEquals("comp1", assignment.companionId)
+    }
+}

--- a/app/src/test/kotlin/com/chimera/data/EnvironmentConfigTest.kt
+++ b/app/src/test/kotlin/com/chimera/data/EnvironmentConfigTest.kt
@@ -1,0 +1,35 @@
+package com.chimera.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class EnvironmentConfigTest {
+
+    @Test
+    fun `ProviderMode AUTO exists`() {
+        assertEquals("AUTO", ProviderMode.AUTO.name)
+    }
+
+    @Test
+    fun `ProviderMode FAKE exists`() {
+        assertEquals("FAKE", ProviderMode.FAKE.name)
+    }
+
+    @Test
+    fun `ProviderMode GEMINI_ONLY exists`() {
+        assertEquals("GEMINI_ONLY", ProviderMode.GEMINI_ONLY.name)
+    }
+
+    @Test
+    fun `ProviderMode valueOf works for all modes`() {
+        ProviderMode.values().forEach { mode ->
+            assertEquals(mode, ProviderMode.valueOf(mode.name))
+        }
+    }
+
+    @Test
+    fun `ProviderMode has 4 values`() {
+        assertEquals(4, ProviderMode.values().size)
+    }
+}

--- a/app/src/test/kotlin/com/chimera/data/NightEventProviderTest.kt
+++ b/app/src/test/kotlin/com/chimera/data/NightEventProviderTest.kt
@@ -1,0 +1,89 @@
+package com.chimera.data
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NightEventProviderTest {
+
+    private lateinit var provider: NightEventProvider
+
+    @Before
+    fun setup() {
+        provider = NightEventProvider()
+    }
+
+    @Test
+    fun `returns non-null event for neutral morale`() {
+        val event = provider.getRandomEvent(0.5f)
+        assertNotNull(event)
+        assertTrue(event.title.isNotBlank())
+    }
+
+    @Test
+    fun `returns non-null event for low morale`() {
+        val event = provider.getRandomEvent(0.1f)
+        assertNotNull(event)
+    }
+
+    @Test
+    fun `returns non-null event for high morale`() {
+        val event = provider.getRandomEvent(0.9f)
+        assertNotNull(event)
+    }
+
+    @Test
+    fun `all events have at least 2 choices`() {
+        // Run many times to sample the full pool
+        val seen = mutableSetOf<String>()
+        repeat(100) {
+            val event = provider.getRandomEvent(0.5f)
+            seen.add(event.id)
+            assertTrue("Event ${event.id} has ${event.choices.size} choices", event.choices.size >= 2)
+        }
+        // Should have seen multiple distinct events
+        assertTrue("Only saw ${seen.size} distinct events", seen.size >= 3)
+    }
+
+    @Test
+    fun `all events have non-blank narrative`() {
+        repeat(50) {
+            val event = provider.getRandomEvent(0.5f)
+            assertTrue(event.narrative.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `all choices have non-blank outcome text`() {
+        repeat(50) {
+            val event = provider.getRandomEvent(0.5f)
+            event.choices.forEach { choice ->
+                assertTrue("Choice '${choice.text}' has blank outcome", choice.outcome.isNotBlank())
+            }
+        }
+    }
+
+    @Test
+    fun `low morale biases toward tension events`() {
+        var tensionCount = 0
+        val tensionIds = setOf("strange_noise", "companion_argument", "supplies_stolen", "watch_fire_dies")
+        repeat(100) {
+            val event = provider.getRandomEvent(0.1f)
+            if (event.id in tensionIds) tensionCount++
+        }
+        // At 10% morale, 60% chance of tension events per call
+        assertTrue("Expected tension bias, got $tensionCount/100", tensionCount > 30)
+    }
+
+    @Test
+    fun `morale deltas are bounded`() {
+        repeat(50) {
+            val event = provider.getRandomEvent(0.5f)
+            event.choices.forEach { choice ->
+                assertTrue(choice.moraleDelta >= -0.15f)
+                assertTrue(choice.moraleDelta <= 0.15f)
+            }
+        }
+    }
+}

--- a/core-model/src/test/kotlin/com/chimera/model/ModelValidationTest.kt
+++ b/core-model/src/test/kotlin/com/chimera/model/ModelValidationTest.kt
@@ -1,0 +1,81 @@
+package com.chimera.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelValidationTest {
+
+    @Test
+    fun `CharacterState disposition bounds are correct`() {
+        assertEquals(-1.0f, CharacterState.DISPOSITION_MIN, 0.001f)
+        assertEquals(1.0f, CharacterState.DISPOSITION_MAX, 0.001f)
+    }
+
+    @Test
+    fun `SaveSlot default chapter is prologue`() {
+        val slot = SaveSlot(slotIndex = 0, playerName = "Test")
+        assertEquals("prologue", slot.chapterTag)
+    }
+
+    @Test
+    fun `SaveSlot default is empty`() {
+        val slot = SaveSlot(slotIndex = 0, playerName = "")
+        assertTrue(slot.isEmpty)
+    }
+
+    @Test
+    fun `CharacterRole enum has all expected values`() {
+        val roles = CharacterRole.values().map { it.name }
+        assertTrue(roles.contains("PROTAGONIST"))
+        assertTrue(roles.contains("COMPANION"))
+        assertTrue(roles.contains("NPC_ALLY"))
+        assertTrue(roles.contains("NPC_NEUTRAL"))
+        assertTrue(roles.contains("NPC_HOSTILE"))
+        assertTrue(roles.contains("FACTION_LEADER"))
+    }
+
+    @Test
+    fun `DialogueTurnResult defaults are safe`() {
+        val result = DialogueTurnResult(npcLine = "test")
+        assertEquals("neutral", result.emotion)
+        assertEquals(0f, result.relationshipDelta, 0.001f)
+        assertTrue(result.flags.isEmpty())
+        assertTrue(result.memoryCandidates.isEmpty())
+    }
+
+    @Test
+    fun `SceneContract default maxTurns is 12`() {
+        val contract = SceneContract("id", "title", "npc", "NPC Name", "setting")
+        assertEquals(12, contract.maxTurns)
+    }
+
+    @Test
+    fun `SceneContract default forbiddenTopics is empty`() {
+        val contract = SceneContract("id", "title", "npc", "NPC", "setting")
+        assertTrue(contract.forbiddenTopics.isEmpty())
+    }
+
+    @Test
+    fun `MemoryShard default importance is 0_5`() {
+        val shard = MemoryShard(saveSlotId = 1, sceneId = "s", characterId = "c", summary = "test")
+        assertEquals(0.5f, shard.importanceScore, 0.001f)
+    }
+
+    @Test
+    fun `PlayerInput default is not quick intent`() {
+        val input = PlayerInput(text = "hello")
+        assertEquals(false, input.isQuickIntent)
+    }
+
+    @Test
+    fun `GameEvent sealed hierarchy has expected subclasses`() {
+        val slotSelected = GameEvent.SaveSlotSelected(1)
+        val sceneEntered = GameEvent.SceneEntered("s1")
+        val relationshipChanged = GameEvent.RelationshipChanged("npc", 0.1f, 0.5f)
+
+        assertTrue(slotSelected is GameEvent)
+        assertTrue(sceneEntered is GameEvent)
+        assertTrue(relationshipChanged is GameEvent)
+    }
+}


### PR DESCRIPTION
## Summary

29 new tests pushing total from 94 to **123** (target was 120+):

- **NightEventProviderTest** (8): morale-weighted selection, choice validation, tension bias at low morale
- **DutyAssignmentTest** (6): duty type morale effects, label validation, default state
- **EnvironmentConfigTest** (5): ProviderMode enum completeness and round-trip
- **ModelValidationTest** (10): domain model defaults, bounds, enum completeness, sealed hierarchy

## Test plan

- [ ] `./gradlew test` passes all 123 tests
- [ ] No test depends on Android framework (all pure JUnit)

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb