### PR TITLE
Act 3: The Shattered Coast + crafting system (DB v7)

### DIFF
--- a/app/src/main/assets/act3_map.json
+++ b/app/src/main/assets/act3_map.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "broken_shore",
+    "name": "The Broken Shore",
+    "description": "A windswept beach littered with wreckage. The air tastes of salt and ash.",
+    "sceneId": "coastal_arrival",
+    "connectedTo": ["ashen_throne", "salvage_yard", "smugglers_cove"],
+    "xFraction": 0.5,
+    "yFraction": 0.9
+  },
+  {
+    "id": "salvage_yard",
+    "name": "Salvage Yard",
+    "description": "A massive forge built from shipwrecks. Metal screams under Kael's hammer.",
+    "sceneId": "salvage_yard",
+    "connectedTo": ["broken_shore", "tidewall"],
+    "xFraction": 0.2,
+    "yFraction": 0.7
+  },
+  {
+    "id": "smugglers_cove",
+    "name": "Smuggler's Cove",
+    "description": "A hidden cove where salvage is traded in whispers and shadows.",
+    "sceneId": "smugglers_cove",
+    "connectedTo": ["broken_shore", "drowned_temple"],
+    "xFraction": 0.8,
+    "yFraction": 0.65
+  },
+  {
+    "id": "tidewall",
+    "name": "The Tidewall",
+    "description": "A sea wall garrison. Waves crash below and guards pace above.",
+    "sceneId": "tidewall_garrison",
+    "connectedTo": ["salvage_yard", "tidal_lab", "reforged_fleet"],
+    "xFraction": 0.25,
+    "yFraction": 0.45
+  },
+  {
+    "id": "drowned_temple",
+    "name": "Drowned Temple",
+    "description": "Half-submerged stone columns rise from the tide. Something sacred lingers.",
+    "sceneId": "drowned_temple",
+    "connectedTo": ["smugglers_cove", "tide_amphitheater"],
+    "xFraction": 0.75,
+    "yFraction": 0.4
+  },
+  {
+    "id": "tidal_lab",
+    "name": "Tidal Laboratory",
+    "description": "A cave system converted to a research lab. Glass vials glow with corruption samples.",
+    "sceneId": "aria_laboratory",
+    "connectedTo": ["tidewall", "tide_amphitheater"],
+    "xFraction": 0.4,
+    "yFraction": 0.25
+  },
+  {
+    "id": "tide_amphitheater",
+    "name": "Tide Amphitheater",
+    "description": "A natural amphitheater carved by waves. Tidal pools glow at night.",
+    "sceneId": "dara_ritual",
+    "connectedTo": ["drowned_temple", "tidal_lab", "heart_of_tide"],
+    "xFraction": 0.6,
+    "yFraction": 0.15
+  },
+  {
+    "id": "reforged_fleet",
+    "name": "Reforged Fleet",
+    "description": "Warships anchored in formation. The Reforged banner flies from every mast.",
+    "sceneId": "seren_fleet",
+    "connectedTo": ["tidewall", "heart_of_tide"],
+    "xFraction": 0.15,
+    "yFraction": 0.1
+  },
+  {
+    "id": "heart_of_tide",
+    "name": "Heart of the Tide",
+    "description": "An undersea cavern where corruption has built a throne of living crystal.",
+    "sceneId": "act3_climax",
+    "connectedTo": ["tide_amphitheater", "reforged_fleet"],
+    "xFraction": 0.5,
+    "yFraction": 0.02,
+    "unlockRequirements": {
+      "completedScenes": ["dara_ritual", "seren_fleet"]
+    }
+  }
+]

--- a/app/src/main/assets/act3_npcs.json
+++ b/app/src/main/assets/act3_npcs.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "dara",
+    "name": "Dara",
+    "title": "The Tide-Speaker",
+    "role": "NPC_ALLY",
+    "initialDisposition": 0.1,
+    "archetype": "GROWTH_AND_UNDERINVESTMENT",
+    "portraitResName": null
+  },
+  {
+    "id": "rook",
+    "name": "Rook",
+    "title": "The Salvager",
+    "role": "NPC_NEUTRAL",
+    "initialDisposition": 0.0,
+    "archetype": "FIXES_THAT_FAIL",
+    "portraitResName": null
+  },
+  {
+    "id": "corruption",
+    "name": "The Living Corruption",
+    "title": "The Tide's Hunger",
+    "role": "NPC_HOSTILE",
+    "initialDisposition": -0.8,
+    "archetype": null,
+    "portraitResName": null
+  }
+]

--- a/app/src/main/assets/act3_scenes.json
+++ b/app/src/main/assets/act3_scenes.json
@@ -1,0 +1,106 @@
+[
+  {
+    "sceneId": "coastal_arrival",
+    "sceneTitle": "The Broken Shore",
+    "npcId": "dara",
+    "npcName": "Dara the Tide-Speaker",
+    "setting": "a windswept beach littered with wreckage from the Hollow's collapse",
+    "stakes": "A mystic of the coast warns that the corruption has spread to the sea itself",
+    "maxTurns": 10,
+    "allowedReveals": ["coastal_corruption", "tide_prophecy"]
+  },
+  {
+    "sceneId": "salvage_yard",
+    "sceneTitle": "The Salvage Yard",
+    "npcId": "kael",
+    "npcName": "Kael the Forgemaster",
+    "setting": "a massive open-air forge built from shipwrecks, where Kael has set up a new workshop",
+    "stakes": "Kael can craft weapons against the spreading corruption -- but needs rare materials",
+    "maxTurns": 10,
+    "allowedReveals": ["forge_history", "corruption_weakness"]
+  },
+  {
+    "sceneId": "drowned_temple",
+    "sceneTitle": "The Drowned Temple",
+    "npcId": "vessa",
+    "npcName": "Vessa the Hollow Priestess",
+    "setting": "a half-submerged temple where the tide brings offerings no one asked for",
+    "stakes": "Vessa believes the corruption can be purified here -- but the ritual demands sacrifice",
+    "maxTurns": 12,
+    "allowedReveals": ["corruption_source", "purification_ritual", "hollow_faith"],
+    "forbiddenTopics": ["escape_route"]
+  },
+  {
+    "sceneId": "smugglers_cove",
+    "sceneTitle": "The Smuggler's Cove",
+    "npcId": "rook",
+    "npcName": "Rook the Salvager",
+    "setting": "a hidden cove where salvaged goods are traded outside faction control",
+    "stakes": "Rook has crafting materials but trades only in secrets and favors",
+    "maxTurns": 10,
+    "allowedReveals": ["trade_routes", "faction_secrets"]
+  },
+  {
+    "sceneId": "tidewall_garrison",
+    "sceneTitle": "The Tidewall",
+    "npcId": "marcus",
+    "npcName": "Marcus the Guard",
+    "setting": "a sea wall garrison where Marcus has been reassigned after the Hollow fell",
+    "stakes": "Marcus has intel on coastal faction movements but his loyalty is divided",
+    "maxTurns": 10,
+    "allowedReveals": ["garrison_movements", "faction_secrets"],
+    "forbiddenTopics": ["deserter_truth"]
+  },
+  {
+    "sceneId": "aria_laboratory",
+    "sceneTitle": "The Tidal Laboratory",
+    "npcId": "aria",
+    "npcName": "Aria the Scholar",
+    "setting": "a cave system Aria has converted into a research lab, studying corruption samples",
+    "stakes": "Aria's research reveals the corruption is alive -- and it's evolving to resist purification",
+    "maxTurns": 12,
+    "allowedReveals": ["corruption_nature", "crown_nature", "evolution_theory"]
+  },
+  {
+    "sceneId": "dara_ritual",
+    "sceneTitle": "The Tide Ritual",
+    "npcId": "dara",
+    "npcName": "Dara the Tide-Speaker",
+    "setting": "a natural amphitheater carved by centuries of waves, filled with tidal pools that glow",
+    "stakes": "Dara leads a purification ritual but the corruption fights back violently",
+    "maxTurns": 8,
+    "allowedReveals": ["tide_prophecy", "purification_ritual", "corruption_weakness"]
+  },
+  {
+    "sceneId": "rook_betrayal",
+    "sceneTitle": "The Double Cross",
+    "npcId": "rook",
+    "npcName": "Rook the Salvager",
+    "setting": "a trap set in the smuggler's cove -- the exits are blocked",
+    "stakes": "Rook reveals they've been selling information to the corruption itself",
+    "maxTurns": 8,
+    "allowedReveals": ["faction_secrets", "corruption_nature"],
+    "forbiddenTopics": ["purification_ritual"]
+  },
+  {
+    "sceneId": "seren_fleet",
+    "sceneTitle": "The Reforged Fleet",
+    "npcId": "seren",
+    "npcName": "Seren of the Reforged",
+    "setting": "aboard a repurposed warship, the flagship of the Reforged coastal fleet",
+    "stakes": "Seren has built a fleet to assault the corruption's source -- but needs your alliance",
+    "maxTurns": 10,
+    "allowedReveals": ["reforged_prophecy", "corruption_weakness"]
+  },
+  {
+    "sceneId": "act3_climax",
+    "sceneTitle": "The Heart of the Tide",
+    "npcId": "corruption",
+    "npcName": "The Living Corruption",
+    "setting": "a massive undersea cavern where the corruption has built a new throne from living crystal",
+    "stakes": "The final confrontation -- purify, dominate, or merge with the corruption",
+    "maxTurns": 8,
+    "allowedReveals": ["corruption_nature", "corruption_weakness", "evolution_theory", "tide_prophecy"],
+    "forbiddenTopics": []
+  }
+]

--- a/app/src/main/assets/crafting_recipes.json
+++ b/app/src/main/assets/crafting_recipes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "tide_ward",
+    "name": "Tide Ward",
+    "description": "A protective charm against the corruption's influence. Requires purified coral and hollow iron.",
+    "resultItemId": "tide_ward",
+    "resultName": "Tide Ward",
+    "resultCategory": "artifact",
+    "resultRarity": "rare",
+    "ingredientsJson": "[{\"itemId\":\"purified_coral\",\"quantity\":2},{\"itemId\":\"hollow_iron\",\"quantity\":1}]",
+    "requiredScene": "drowned_temple",
+    "requiredNpc": "vessa"
+  },
+  {
+    "id": "echo_blade",
+    "name": "Echo Blade",
+    "description": "A weapon forged from the Hollow King's resonance. Cuts through corruption like truth through lies.",
+    "resultItemId": "echo_blade",
+    "resultName": "Echo Blade",
+    "resultCategory": "artifact",
+    "resultRarity": "legendary",
+    "ingredientsJson": "[{\"itemId\":\"hollow_iron\",\"quantity\":3},{\"itemId\":\"king_shard\",\"quantity\":1},{\"itemId\":\"forge_ember\",\"quantity\":2}]",
+    "requiredScene": "salvage_yard",
+    "requiredNpc": "kael"
+  },
+  {
+    "id": "memory_vial",
+    "name": "Memory Vial",
+    "description": "Distilled memories that can restore forgotten knowledge. Useful in negotiations.",
+    "resultItemId": "memory_vial",
+    "resultName": "Memory Vial",
+    "resultCategory": "consumable",
+    "resultRarity": "uncommon",
+    "ingredientsJson": "[{\"itemId\":\"memory_dust\",\"quantity\":3},{\"itemId\":\"glass_flask\",\"quantity\":1}]",
+    "requiredScene": null,
+    "requiredNpc": "aria"
+  },
+  {
+    "id": "signal_flare",
+    "name": "Reforged Signal Flare",
+    "description": "A device that summons Reforged allies in battle. One use only.",
+    "resultItemId": "signal_flare",
+    "resultName": "Signal Flare",
+    "resultCategory": "consumable",
+    "resultRarity": "rare",
+    "ingredientsJson": "[{\"itemId\":\"forge_ember\",\"quantity\":2},{\"itemId\":\"salt_crystal\",\"quantity\":1}]",
+    "requiredScene": null,
+    "requiredNpc": "seren"
+  },
+  {
+    "id": "purification_totem",
+    "name": "Purification Totem",
+    "description": "Cleanses corruption from a small area. Essential for the final ritual.",
+    "resultItemId": "purification_totem",
+    "resultName": "Purification Totem",
+    "resultCategory": "key_item",
+    "resultRarity": "legendary",
+    "ingredientsJson": "[{\"itemId\":\"purified_coral\",\"quantity\":3},{\"itemId\":\"tide_essence\",\"quantity\":2},{\"itemId\":\"king_shard\",\"quantity\":1}]",
+    "requiredScene": "dara_ritual",
+    "requiredNpc": "dara"
+  }
+]

--- a/app/src/main/kotlin/com/chimera/data/SceneLoader.kt
+++ b/app/src/main/kotlin/com/chimera/data/SceneLoader.kt
@@ -14,7 +14,7 @@ class SceneLoader @Inject constructor(
     private val json = Json { ignoreUnknownKeys = true }
     private var cache: Map<String, SceneContract>? = null
 
-    private val sceneFiles = listOf("act1_scenes.json", "act2_scenes.json")
+    private val sceneFiles = listOf("act1_scenes.json", "act2_scenes.json", "act3_scenes.json")
 
     fun getScene(sceneId: String): SceneContract? {
         return loadAll()[sceneId]

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -9,8 +9,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.chimera.database.converter.Converters
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
+import com.chimera.database.dao.CraftingRecipeDao
 import com.chimera.database.dao.DialogueTurnDao
 import com.chimera.database.dao.FactionStateDao
+import com.chimera.database.dao.InventoryDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
 import com.chimera.database.dao.QuestDao
@@ -20,8 +22,10 @@ import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.dao.VowDao
 import com.chimera.database.entity.CharacterEntity
 import com.chimera.database.entity.CharacterStateEntity
+import com.chimera.database.entity.CraftingRecipeEntity
 import com.chimera.database.entity.DialogueTurnEntity
 import com.chimera.database.entity.FactionStateEntity
+import com.chimera.database.entity.InventoryItemEntity
 import com.chimera.database.entity.JournalEntryEntity
 import com.chimera.database.entity.MemoryShardEntity
 import com.chimera.database.entity.QuestEntity
@@ -42,9 +46,11 @@ import com.chimera.database.entity.VowEntity
         VowEntity::class,
         RumorPacketEntity::class,
         FactionStateEntity::class,
-        QuestEntity::class
+        QuestEntity::class,
+        InventoryItemEntity::class,
+        CraftingRecipeEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -59,6 +65,8 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     abstract fun journalEntryDao(): JournalEntryDao
     abstract fun vowDao(): VowDao
     abstract fun questDao(): QuestDao
+    abstract fun inventoryDao(): InventoryDao
+    abstract fun craftingRecipeDao(): CraftingRecipeDao
     abstract fun rumorPacketDao(): RumorPacketDao
     abstract fun factionStateDao(): FactionStateDao
 

--- a/core-database/src/main/kotlin/com/chimera/database/dao/CraftingRecipeDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/CraftingRecipeDao.kt
@@ -1,0 +1,30 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.chimera.database.entity.CraftingRecipeEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CraftingRecipeDao {
+
+    @Query("SELECT * FROM crafting_recipes WHERE is_discovered = 1 ORDER BY name")
+    fun observeDiscovered(): Flow<List<CraftingRecipeEntity>>
+
+    @Query("SELECT * FROM crafting_recipes ORDER BY name")
+    fun observeAll(): Flow<List<CraftingRecipeEntity>>
+
+    @Query("SELECT * FROM crafting_recipes WHERE id = :id")
+    suspend fun getById(id: String): CraftingRecipeEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(recipe: CraftingRecipeEntity)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertAll(recipes: List<CraftingRecipeEntity>)
+
+    @Query("UPDATE crafting_recipes SET is_discovered = 1 WHERE id = :id")
+    suspend fun discover(id: String)
+}

--- a/core-database/src/main/kotlin/com/chimera/database/dao/InventoryDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/InventoryDao.kt
@@ -1,0 +1,36 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.chimera.database.entity.InventoryItemEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface InventoryDao {
+
+    @Query("SELECT * FROM inventory_items WHERE save_slot_id = :slotId ORDER BY category, name")
+    fun observeAll(slotId: Long): Flow<List<InventoryItemEntity>>
+
+    @Query("SELECT * FROM inventory_items WHERE save_slot_id = :slotId AND category = :category ORDER BY name")
+    fun observeByCategory(slotId: Long, category: String): Flow<List<InventoryItemEntity>>
+
+    @Query("SELECT * FROM inventory_items WHERE save_slot_id = :slotId AND item_id = :itemId")
+    suspend fun getByItemId(slotId: Long, itemId: String): InventoryItemEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(item: InventoryItemEntity)
+
+    @Query("UPDATE inventory_items SET quantity = quantity + :amount WHERE save_slot_id = :slotId AND item_id = :itemId")
+    suspend fun addQuantity(slotId: Long, itemId: String, amount: Int)
+
+    @Query("UPDATE inventory_items SET quantity = quantity - :amount WHERE save_slot_id = :slotId AND item_id = :itemId AND quantity >= :amount")
+    suspend fun removeQuantity(slotId: Long, itemId: String, amount: Int): Int
+
+    @Query("DELETE FROM inventory_items WHERE save_slot_id = :slotId AND item_id = :itemId AND quantity <= 0")
+    suspend fun cleanupEmpty(slotId: Long, itemId: String)
+
+    @Query("SELECT COUNT(*) FROM inventory_items WHERE save_slot_id = :slotId")
+    fun observeItemCount(slotId: Long): Flow<Int>
+}

--- a/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import com.chimera.database.ChimeraGameDatabase
 import com.chimera.database.dao.CharacterDao
 import com.chimera.database.dao.CharacterStateDao
+import com.chimera.database.dao.CraftingRecipeDao
 import com.chimera.database.dao.DialogueTurnDao
+import com.chimera.database.dao.InventoryDao
 import com.chimera.database.dao.FactionStateDao
 import com.chimera.database.dao.JournalEntryDao
 import com.chimera.database.dao.MemoryShardDao
@@ -41,4 +43,6 @@ object DatabaseModule {
     @Provides fun provideRumorPacketDao(db: ChimeraGameDatabase): RumorPacketDao = db.rumorPacketDao()
     @Provides fun provideFactionStateDao(db: ChimeraGameDatabase): FactionStateDao = db.factionStateDao()
     @Provides fun provideQuestDao(db: ChimeraGameDatabase): QuestDao = db.questDao()
+    @Provides fun provideInventoryDao(db: ChimeraGameDatabase): InventoryDao = db.inventoryDao()
+    @Provides fun provideCraftingRecipeDao(db: ChimeraGameDatabase): CraftingRecipeDao = db.craftingRecipeDao()
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/CraftingRecipeEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/CraftingRecipeEntity.kt
@@ -1,0 +1,39 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "crafting_recipes")
+data class CraftingRecipeEntity(
+    @PrimaryKey
+    val id: String,
+
+    val name: String,
+
+    val description: String,
+
+    @ColumnInfo(name = "result_item_id")
+    val resultItemId: String,
+
+    @ColumnInfo(name = "result_name")
+    val resultName: String,
+
+    @ColumnInfo(name = "result_category")
+    val resultCategory: String = "artifact",
+
+    @ColumnInfo(name = "result_rarity")
+    val resultRarity: String = "rare",
+
+    @ColumnInfo(name = "ingredients_json")
+    val ingredientsJson: String = "[]", // [{"itemId":"x","quantity":1}]
+
+    @ColumnInfo(name = "required_scene")
+    val requiredScene: String? = null, // must complete this scene to unlock
+
+    @ColumnInfo(name = "required_npc")
+    val requiredNpc: String? = null, // must know this NPC
+
+    @ColumnInfo(name = "is_discovered")
+    val isDiscovered: Boolean = false
+)

--- a/core-database/src/main/kotlin/com/chimera/database/entity/InventoryItemEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/InventoryItemEntity.kt
@@ -1,0 +1,46 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "inventory_items",
+    foreignKeys = [
+        ForeignKey(
+            entity = SaveSlotEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["save_slot_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("save_slot_id"), Index(value = ["save_slot_id", "item_id"], unique = true)]
+)
+data class InventoryItemEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    @ColumnInfo(name = "item_id")
+    val itemId: String,
+
+    val name: String,
+
+    val description: String = "",
+
+    val category: String = "material", // material, artifact, consumable, key_item
+
+    val quantity: Int = 1,
+
+    val rarity: String = "common", // common, uncommon, rare, legendary
+
+    @ColumnInfo(name = "source_scene_id")
+    val sourceSceneId: String? = null,
+
+    @ColumnInfo(name = "acquired_at")
+    val acquiredAt: Long = System.currentTimeMillis()
+)


### PR DESCRIPTION
## Summary

- **Crafting system**: InventoryItemEntity (4 categories, rarity, quantity), CraftingRecipeEntity (ingredient lists, NPC/scene unlock gates), 5 authored recipes, DB v7
- **Act 3 "The Shattered Coast"**: 10 new scenes, 9 map nodes, 3 new NPCs (Dara the Tide-Speaker, Rook the Salvager, The Living Corruption)
- **Returning NPCs**: Kael, Vessa, Marcus, Aria, Seren with coastal evolved arcs
- **Story**: Corruption spreads to the sea, crafting essential for purification, climax offers 3 endings
- **SceneLoader**: Updated for 3-act loading

## Test plan

- [ ] Act 3 scenes loadable via SceneLoader
- [ ] InventoryDao upsert/quantity operations work
- [ ] CraftingRecipeDao discovery tracking works
- [ ] 9 map nodes display for Act 3 region
- [ ] Crafting recipes JSON loads without errors

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb