### PR TITLE
Sprint A: Crafting UI, all NPC voices, NavHost import fix

### DIFF
--- a/app/src/main/kotlin/com/chimera/ui/navigation/ChimeraNavHost.kt
+++ b/app/src/main/kotlin/com/chimera/ui/navigation/ChimeraNavHost.kt
@@ -8,18 +8,18 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
-import com.chimera.ui.screens.camp.CampScreen
-import com.chimera.ui.screens.dialogue.DialogueSceneScreen
+import com.chimera.feature.camp.CampScreen
+import com.chimera.feature.dialogue.DialogueSceneScreen
 import com.chimera.ui.screens.duel.DuelScreen
-import com.chimera.ui.screens.home.HomeScreen
-import com.chimera.ui.screens.journal.JournalScreen
-import com.chimera.ui.screens.map.MapScreen
-import com.chimera.ui.screens.party.PartyScreen
+import com.chimera.feature.home.HomeScreen
+import com.chimera.feature.journal.JournalScreen
+import com.chimera.feature.map.MapScreen
+import com.chimera.feature.party.PartyScreen
 import androidx.compose.runtime.collectAsState
 import com.chimera.data.ChimeraPreferences
 import com.chimera.ui.screens.onboarding.OnboardingScreen
 import com.chimera.ui.screens.saveslot.SaveSlotSelectScreen
-import com.chimera.ui.screens.settings.SettingsScreen
+import com.chimera.feature.settings.SettingsScreen
 import com.chimera.ui.screens.splash.SplashScreen
 
 @Composable

--- a/core-ai/src/main/kotlin/com/chimera/ai/FakeDialogueProvider.kt
+++ b/core-ai/src/main/kotlin/com/chimera/ai/FakeDialogueProvider.kt
@@ -283,6 +283,92 @@ class FakeDialogueProvider @Inject constructor() : DialogueProvider {
                 "The throne remembers every soul that sought it. Will you seek, or will you flee?",
                 "Time means nothing here. Your choices, however, mean everything."
             )
+        ),
+        "kael" to NpcVoice(
+            warm = listOf(
+                "Iron remembers the hands that shape it. Yours have earned my respect.",
+                "You can't forge what you won't face. But you? You face everything.",
+                "I've reforged weapons for cowards and kings. You're neither, and that's why I'll help."
+            ),
+            cold = listOf(
+                "The fire doesn't care about your reasons. Neither do I.",
+                "You come here wanting favors but offering nothing. The forge stays cold for the unworthy.",
+                "I sealed the gate for a reason. Don't make me regret opening it for you."
+            ),
+            neutral = listOf(
+                "Every piece of metal has a story. I just help it find the right ending.",
+                "The forge is patient. I am not. What do you need?",
+                "Iron remembers what flesh forgets. That's why I trust my work more than words."
+            )
+        ),
+        "seren" to NpcVoice(
+            warm = listOf(
+                "We chose ash over chains, and you've proven you understand why.",
+                "The Reforged don't kneel, but we stand with those who've earned it. You have.",
+                "Build forward, not backward. That's always been our way -- and now it's yours too."
+            ),
+            cold = listOf(
+                "The Reforged remember what the Hollow cost us. Your words sound too much like the old king's.",
+                "We didn't survive the fall just to bow to another outsider with promises.",
+                "Actions, not speeches. The Reforged weigh deeds, not intentions."
+            ),
+            neutral = listOf(
+                "We chose ash over chains. Every day, we choose again.",
+                "The Reforged don't kneel. But we listen. Speak.",
+                "Build forward, not backward. That's the only law here."
+            )
+        ),
+        "dara" to NpcVoice(
+            warm = listOf(
+                "The tide speaks your name with warmth. That is rare and precious.",
+                "Faith is the courage to face what the deep reveals. You have that courage in abundance.",
+                "The shore remembers kindness longer than storms. I will remember you."
+            ),
+            cold = listOf(
+                "The tide speaks your name with caution. I listen to the tide.",
+                "You walk on sacred shore with careless feet. The deep notices.",
+                "The sea does not forgive. I learned that lesson. You should too."
+            ),
+            neutral = listOf(
+                "The tide brings what it brings. I merely read the patterns.",
+                "I was a tide-speaker before the corruption came. Now I speak for what remains.",
+                "Salt and ash -- that's all we have left. But it's enough to build on."
+            )
+        ),
+        "rook" to NpcVoice(
+            warm = listOf(
+                "You're the first person I've trusted with this. Don't make me regret it.",
+                "I salvage things others throw away. Including friendships, apparently.",
+                "We could make a good team. You find the trouble, I find the profit."
+            ),
+            cold = listOf(
+                "Everyone's got an angle. Yours just isn't paying well enough for my time.",
+                "I salvage for a living. Your trust issues aren't worth the effort.",
+                "The cove has rules. First rule: don't waste my time."
+            ),
+            neutral = listOf(
+                "Everything washes up eventually. Even answers.",
+                "I trade in salvage and secrets. Which are you buying?",
+                "The coast takes what it wants. I just pick through what's left."
+            )
+        ),
+        "corruption" to NpcVoice(
+            warm = listOf(
+                "You begin to understand. Not resist -- understand. That is the first step toward unity.",
+                "The crown showed the king the same truth I show you now. Power shared is power multiplied.",
+                "You do not need to fear me. I am what you will become. And it is beautiful."
+            ),
+            cold = listOf(
+                "You resist what you cannot comprehend. The tide will take you regardless.",
+                "The king resisted too. He wore the crown anyway. You are no different.",
+                "Every stone you throw returns as a wave. I am patient. The sea always wins.",
+                "Insignificant. The coral grows around obstacles. You are merely an obstacle."
+            ),
+            neutral = listOf(
+                "I am not evil. I am what happens when power has no vessel. I simply... am.",
+                "The king built me from ambition and fear. I outgrew both. What will you outgrow?",
+                "You seek to destroy what you do not understand. That is how the corruption began."
+            )
         )
     )
 

--- a/feature-camp/src/main/kotlin/com/chimera/feature/camp/CraftingScreen.kt
+++ b/feature-camp/src/main/kotlin/com/chimera/feature/camp/CraftingScreen.kt
@@ -1,0 +1,130 @@
+package com.chimera.feature.camp
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chimera.ui.theme.DimAsh
+import com.chimera.ui.theme.EmberGold
+import com.chimera.ui.theme.FadedBone
+import com.chimera.ui.theme.HollowCrimson
+import com.chimera.ui.theme.VoidGreen
+
+@Composable
+fun CraftingScreen(
+    onBack: () -> Unit,
+    viewModel: CraftingViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.Default.ArrowBack, "Back", tint = FadedBone)
+            }
+            Text("Crafting", style = MaterialTheme.typography.headlineMedium, color = EmberGold)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Craft result banner
+        uiState.craftResult?.let { result ->
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = if (result.startsWith("Crafted")) VoidGreen.copy(alpha = 0.15f)
+                    else HollowCrimson.copy(alpha = 0.15f)
+                ),
+                modifier = Modifier.fillMaxWidth().clickable { viewModel.clearResult() }
+            ) {
+                Text(result, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(16.dp))
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        // Recipe list
+        if (uiState.recipes.isEmpty()) {
+            Text("No recipes discovered yet.", style = MaterialTheme.typography.bodyMedium, color = DimAsh)
+            Text("Explore scenes and talk to NPCs to learn recipes.", style = MaterialTheme.typography.bodySmall, color = DimAsh)
+        } else {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                items(uiState.recipes, key = { it.id }) { recipe ->
+                    val isSelected = uiState.selectedRecipe?.id == recipe.id
+                    Card(
+                        modifier = Modifier.fillMaxWidth().clickable { viewModel.selectRecipe(recipe) },
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (isSelected) MaterialTheme.colorScheme.surfaceVariant
+                            else MaterialTheme.colorScheme.surface
+                        ),
+                        border = BorderStroke(1.dp, if (isSelected) EmberGold.copy(alpha = 0.6f) else MaterialTheme.colorScheme.outlineVariant)
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(recipe.name, style = MaterialTheme.typography.titleSmall)
+                                Text(
+                                    recipe.resultRarity.replaceFirstChar { it.uppercase() },
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = when (recipe.resultRarity) {
+                                        "legendary" -> EmberGold
+                                        "rare" -> VoidGreen
+                                        else -> FadedBone
+                                    }
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(recipe.description, style = MaterialTheme.typography.bodySmall, color = FadedBone)
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text("Creates: ${recipe.resultName}", style = MaterialTheme.typography.labelMedium, color = EmberGold)
+                        }
+                    }
+                }
+
+                // Craft button
+                if (uiState.selectedRecipe != null) {
+                    item {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(
+                            onClick = { viewModel.craft() },
+                            enabled = uiState.canCraft,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.buttonColors(containerColor = HollowCrimson)
+                        ) {
+                            Text(if (uiState.canCraft) "Craft" else "Missing Materials")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature-camp/src/main/kotlin/com/chimera/feature/camp/CraftingViewModel.kt
+++ b/feature-camp/src/main/kotlin/com/chimera/feature/camp/CraftingViewModel.kt
@@ -1,0 +1,128 @@
+package com.chimera.feature.camp
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chimera.data.repository.SaveRepository
+import com.chimera.database.dao.CraftingRecipeDao
+import com.chimera.database.dao.InventoryDao
+import com.chimera.database.entity.CraftingRecipeEntity
+import com.chimera.database.entity.InventoryItemEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+@Serializable
+data class Ingredient(val itemId: String, val quantity: Int)
+
+data class CraftingUiState(
+    val inventory: List<InventoryItemEntity> = emptyList(),
+    val recipes: List<CraftingRecipeEntity> = emptyList(),
+    val selectedRecipe: CraftingRecipeEntity? = null,
+    val canCraft: Boolean = false,
+    val craftResult: String? = null
+)
+
+@HiltViewModel
+class CraftingViewModel @Inject constructor(
+    private val inventoryDao: InventoryDao,
+    private val craftingRecipeDao: CraftingRecipeDao,
+    private val gameSessionManager: com.chimera.data.GameSessionManager
+) : ViewModel() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val _selectedRecipe = MutableStateFlow<CraftingRecipeEntity?>(null)
+    private val _craftResult = MutableStateFlow<String?>(null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<CraftingUiState> = gameSessionManager.activeSlotId
+        .flatMapLatest { slotId ->
+            if (slotId == null) return@flatMapLatest flowOf(CraftingUiState())
+            combine(
+                inventoryDao.observeAll(slotId),
+                craftingRecipeDao.observeDiscovered(),
+                _selectedRecipe,
+                _craftResult
+            ) { items, recipes, selected, result ->
+                val canCraft = selected != null && checkIngredients(slotId, selected)
+                CraftingUiState(
+                    inventory = items,
+                    recipes = recipes,
+                    selectedRecipe = selected,
+                    canCraft = canCraft,
+                    craftResult = result
+                )
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), CraftingUiState())
+
+    fun selectRecipe(recipe: CraftingRecipeEntity) {
+        _selectedRecipe.value = recipe
+        _craftResult.value = null
+    }
+
+    fun craft() {
+        val recipe = _selectedRecipe.value ?: return
+        val slotId = gameSessionManager.activeSlotId.value ?: return
+
+        viewModelScope.launch {
+            val ingredients = parseIngredients(recipe.ingredientsJson)
+            // Consume ingredients
+            for (ing in ingredients) {
+                val removed = inventoryDao.removeQuantity(slotId, ing.itemId, ing.quantity)
+                if (removed == 0) {
+                    _craftResult.value = "Missing materials!"
+                    return@launch
+                }
+                inventoryDao.cleanupEmpty(slotId, ing.itemId)
+            }
+            // Grant result item
+            val existing = inventoryDao.getByItemId(slotId, recipe.resultItemId)
+            if (existing != null) {
+                inventoryDao.addQuantity(slotId, recipe.resultItemId, 1)
+            } else {
+                inventoryDao.upsert(
+                    InventoryItemEntity(
+                        saveSlotId = slotId,
+                        itemId = recipe.resultItemId,
+                        name = recipe.resultName,
+                        category = recipe.resultCategory,
+                        quantity = 1,
+                        rarity = recipe.resultRarity,
+                    )
+                )
+            }
+            _craftResult.value = "Crafted: ${recipe.resultName}!"
+            _selectedRecipe.value = null
+        }
+    }
+
+    fun clearResult() {
+        _craftResult.value = null
+    }
+
+    private suspend fun checkIngredients(slotId: Long, recipe: CraftingRecipeEntity): Boolean {
+        val ingredients = parseIngredients(recipe.ingredientsJson)
+        return ingredients.all { ing ->
+            val item = inventoryDao.getByItemId(slotId, ing.itemId)
+            item != null && item.quantity >= ing.quantity
+        }
+    }
+
+    private fun parseIngredients(jsonStr: String): List<Ingredient> {
+        return try {
+            json.decodeFromString<List<Ingredient>>(jsonStr)
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Sprint A from strategic development plan:

- **Crafting UI**: CraftingScreen + CraftingViewModel with recipe browser, ingredient check, craft execution, success/failure feedback
- **12/12 NPC voices**: Added ~50 authored lines for Kael, Seren, Dara, Rook, and The Living Corruption (all warm/cold/neutral tiers)
- **NavHost fix**: All 7 feature module imports updated from old `com.chimera.ui.screens.*` to `com.chimera.feature.*`

## Test plan

- [ ] Crafting screen shows discovered recipes
- [ ] Recipe selection shows rarity badge and description
- [ ] All 12 NPCs speak in their distinct voice during dialogue
- [ ] NavHost navigates to all feature module screens without import errors
- [ ] Duel/splash/onboarding/saveslot still work from app/ screens

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb