### PR TITLE
CLAUDE.md: adopt user's Android-first operational instruction set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,85 +1,106 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This repository is Android-first. Treat the canonical build entry point as the repository root, not any subdirectory.
 
-## Project Architecture
+## Source of truth
 
-**Chimera: Ashes of the Hollow King** is an Android-first narrative RPG built on a deterministic NPC simulation engine.
+- The supported Gradle project is the root project defined by `settings.gradle.kts`.
+- The canonical app module is `:app`, backed by 15 supporting modules (`chimera-core`, `core-model`, `core-ui`, `core-database`, `core-network`, `core-ai`, `core-data`, `domain`, and 7 `feature-*` modules).
+- Prefer the current module layout over any older parallel implementations.
 
-### North Star
+## Primary objective
 
-NPC simulation SDK for story-driven Android games. Chimera Core owns truth (deterministic state transitions, archetype simulation, relationship reducers). Android client owns play. AI service owns expression (optional dialogue flavor).
+Your job is to help consolidate and improve the Android application using the existing stack:
+- Kotlin
+- Jetpack Compose
+- Hilt
+- Room
+- Navigation Compose
+- Coroutines
+- JUnit / Android test
 
-### Module Structure
+Do not expand the project into web, Netlify, Vercel, or generic chatbot work unless the repository is explicitly restructured to support that.
+
+## Working rules
+
+1. Always inspect the current root build files before making architectural assumptions.
+2. Assume documentation may be stale until confirmed by code.
+3. Prefer small, reviewable changes over sweeping rewrites.
+4. Preserve buildability after each change.
+5. When you find contradictions between docs and code, treat code as authoritative and propose doc fixes.
+6. Do not add new product surfaces while the repository still contains duplicate or legacy paths.
+
+## Module structure
 
 ```
-:chimera-core    Pure Kotlin simulation engine (zero Android deps)
-:core-model      Pure Kotlin domain data classes (no Android deps)
-:core-database   Android library: Room entities, DAOs, Hilt DI
-:core-network    Android library: Ktor HTTP client
-:core-ai         Optional AI adapter: providers, parser, assembler (plugin, not core)
-:core-data       Android library: repositories, services, data loaders
-:core-ui         Android library: shared Compose theme + components
-:domain          Use cases bridging core logic and data
-:feature-*       7 feature modules (home, map, dialogue, camp, journal, party, settings)
-:app             Android application: navigation, DI, entry point
+chimera-core     Pure Kotlin simulation engine (zero Android deps)
+                 ├── RelationshipArchetypeEngine
+                 ├── DuelEngine
+                 ├── GameStateMachine
+                 └── GameEventBus
+
+core-model       Pure Kotlin domain data classes
+core-database    Android library: Room entities, DAOs, Hilt DI
+core-network     Android library: Ktor HTTP client
+core-ai          Optional AI adapter: providers, parser, assembler (plugin, not core)
+core-data        Android library: repositories, services, data loaders
+core-ui          Android library: shared Compose theme + components
+domain           Use cases bridging core logic and data
+feature-*        7 feature modules (home, map, dialogue, camp, journal, party, settings)
+app              Android application: navigation, DI, entry point
 ```
 
-### Key Components
+### Architecture direction
 
-1. **chimera-core** (pure Kotlin, no Android):
-   - `RelationshipArchetypeEngine`: Systems-thinking feedback loops (Shifting the Burden, Escalation, Growth & Underinvestment, Fixes That Fail)
-   - `DuelEngine`: Stance-based ritual combat (strike/ward/feint) with omen resources
-   - `GameStateMachine`: Deterministic phase transitions
-   - `GameEventBus`: SharedFlow-based event system
+- `chimera-core/` owns simulation truth: deterministic state transitions, archetype engines, combat logic
+- `core-ai/` is an optional adapter plugin — AI does not own game state, progression, or simulation truth
+- `app/di/ChimeraModule` provides core simulation; `app/di/AiAdapterModule` provides AI separately
+- Domain logic is Android-light where possible so it is testable without UI
 
-2. **Room Database** (`core-database`): v7 schema with 13 entities
+## Commands
 
-3. **AI Adapter** (`core-ai`): Optional plugin providing dialogue flavor via free-tier providers (Gemini, Groq, OpenRouter). Game works fully offline with authored `FakeDialogueProvider`. AI does not own game state or progression.
+Run commands from the repository root:
 
-4. **Repositories** (`core-data`): Save, Character, Dialogue, Journal, Camp
-
-5. **Use Cases** (`domain`): 7 orchestration classes
-
-### Data Flow
-- Player selects save slot -> GameSessionManager stores active slot
-- Player enters scene from Map/Home -> ChimeraNavHost navigates to DialogueSceneScreen
-- DialogueSceneViewModel creates SceneInstance, loads CharacterState and MemoryShards
-- Player submits input -> DialogueOrchestrator generates turn (AI or authored fallback)
-- **chimera-core** owns relationship state transitions via RelationshipArchetypeEngine
-- Turn persisted to DialogueTurnDao, memory candidates batch-inserted via MemoryShardDao
-- Scene completion generates JournalEntry automatically
-- Journal/Camp/Party/Map screens read state through DAOs scoped to active save slot
-
-## Development Commands
-
-### Build (from project root)
 ```bash
-./gradlew assembleMockDebug      # Build with offline AI
-./gradlew assembleProdRelease    # Build with cloud AI
-./gradlew testMockDebugUnitTest  # Run all tests
+./gradlew assembleMockDebug      # Debug build with offline-only AI
+./gradlew assembleProdRelease    # Release build with cloud AI
+./gradlew testMockDebugUnitTest  # Run all unit tests
 ./gradlew :chimera-core:test     # Core engine tests only (no Android)
 ./gradlew detekt                 # Static analysis
-./gradlew clean build            # Clean build
+./gradlew clean build            # Full clean build
 ```
 
+Use additional Android test or lint commands only after the base build is healthy.
+
+## Documentation policy
+
+When changing architecture, build paths, or project scope:
+- Update README.md
+- Update this CLAUDE.md
+- Remove stale references to any surfaces that are no longer real
+
+## Definition of done for cleanup work
+
+A task is not complete until:
+- The root build path is correct
+- The Android app has one canonical source path
+- Stale duplicate surfaces are removed or clearly marked legacy
+- Docs match the actual repository structure
+
 ## Testing
+
 - chimera-core tests: pure JUnit, no Android framework needed
-- DAO tests: in-memory Room database
-- ViewModels: Turbine for StateFlow testing
-- DuelEngine: pure unit tests in chimera-core
+- core-ai tests: pure JUnit for parser, assembler, provider router
+- core-database tests: Converters, EntityMappers (pure JUnit)
+- core-model tests: model validation (pure JUnit)
+- core-data tests: NightEventProvider, DutyAssignment (pure JUnit)
 - Uses JUnit 4, Coroutines Test, Turbine, Google Truth
 
 ## Dependencies
+
 - **Android**: Kotlin 1.9.10, Jetpack Compose (BOM 2023.10.01), Hilt 2.48, Room 2.6.1
 - **Navigation**: Compose Navigation 2.7.6, Hilt Navigation Compose 1.1.0
 - **Serialization**: kotlinx-serialization-json 1.6.0
 - **Network**: Ktor 2.3.7 (for AI adapter only)
 - **Build**: Gradle 8.4, AGP 8.1.2, Version Catalog (`gradle/libs.versions.toml`)
 - **Quality**: detekt 1.23.4
-
-## CI/CD
-- **GitHub Actions**: `.github/workflows/android.yml` (lint/test/build pipeline with Gradle caching, Android SDK setup, mock/prod APK + AAB jobs)
-- **PR Checks**: `.github/workflows/build-deploy.yml` (validates PRs against main)
-- **Release**: Tag-based (`refs/tags/v*`) GitHub Release with APK + AAB artifacts
-- **Requirements**: Java 17, Android SDK 34


### PR DESCRIPTION
## Summary

Replaces CLAUDE.md with the user's operational instruction set. Verified zero stale references remain in the active codebase.

### Changes
- **CLAUDE.md**: Full rewrite adopting the user's Android-first specification with source-of-truth rules, working rules, correct build commands, module structure, architecture direction, documentation policy, and definition-of-done criteria
- **Verification**: 0 hits for `creative.consciousness`, `com.xai.chimera`, `DialogGPT`, `consciousness`, `netlify`, `vercel`, `cd android` across all active source

### What the user described vs current state
The user examined main before PR #76 merged. PR #76 has since resolved all issues they identified:
- `android/` deleted, `node_modules` deleted, web files deleted
- Root build.gradle.kts is proper Kotlin DSL
- `applicationId = com.chimera.ashes`
- 16 modules in settings.gradle.kts
- README rewritten for NPC simulation SDK

This PR finalizes the documentation alignment.

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb