### PR TITLE
CLAUDE.md: user's workflow-focused instruction set (verified 5/5 cleanup items)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,82 +1,101 @@
 # CLAUDE.md
 
-This repository is currently Android-first.
+This repository is Android-first.
 
 ## Canonical assumptions
 
-- The supported Gradle entry point is the repository root.
-- The canonical app module is `:app`, backed by `chimera-core` and 14 supporting modules.
-- Code or tooling outside that path is legacy or auxiliary unless the current build proves otherwise.
-- Documentation may be stale; prefer verified build files and source layout over prose.
+- Treat the repository root as the primary build entry point.
+- Treat `:app` as the canonical Android module unless the current build proves otherwise.
+- Treat any web files, deployment files, and automation helpers as legacy or auxiliary until verified.
+- Prefer code over documentation when they conflict.
+- Update documentation whenever you change structure, commands, or scope.
 
 ## Primary objective
 
-Consolidate and improve the Android application in `app/` using the existing stack:
+Consolidate and improve the Android app in `app/` using the existing stack:
 - Kotlin
 - Jetpack Compose
 - Hilt
 - Room
 - Navigation Compose
 - Coroutines
-- Android/JUnit tests
+- Unit and Android tests
 
-Do not expand the project into web deployment, chatbot work, or multi-surface architecture until the repository is structurally clean.
+Do not expand the project into web deployment, chatbot work, or parallel product ideas during cleanup.
 
-## Work priorities
+## Required workflow
 
-1. Ensure the root Gradle project is valid and buildable.
-2. Confirm all supported commands run from the repository root.
-3. Keep Android code organized into clear layers:
-   - `chimera-core/` for deterministic simulation logic (zero Android deps)
-   - `core-*/` for shared infrastructure (database, network, AI adapter, data, UI)
-   - `domain/` for use cases
-   - `feature-*/` for screen-level modules
-   - `app/` for navigation, DI, and entry point
-4. Update docs whenever code structure or build commands change.
+For every task, follow this loop:
 
-## Module structure
+1. **Inspect**
+   - Read the relevant build files and source files.
+   - Check whether the task touches root build truth, Android structure, or stale docs.
+   - Note contradictions between code and docs.
 
-```
-chimera-core     Pure Kotlin simulation engine (zero Android deps)
-core-model       Pure Kotlin domain data classes
-core-database    Room entities, DAOs, Hilt DI
-core-network     Ktor HTTP client
-core-ai          Optional AI adapter (plugin, not core)
-core-data        Repositories, services, data loaders
-core-ui          Shared Compose theme + components
-domain           Use cases
-feature-*        7 feature modules
-app              Navigation, DI, entry point
-```
+2. **Plan**
+   - Choose the smallest safe batch of work.
+   - Prefer cleanup and convergence over adding new features.
 
-## Rules for changes
+3. **Implement**
+   - Make focused changes.
+   - Keep the project buildable after each batch.
+   - Avoid sweeping rewrites unless duplication makes them necessary.
 
-- Make small, reviewable commits.
-- Preserve buildability after each change.
-- Treat contradictions between docs and code as doc bugs first.
-- Do not invent new product scope during cleanup.
-- Prefer plain Kotlin domain logic for simulation features when possible.
+4. **Verify**
+   - Run the relevant Gradle commands from the repository root.
+   - Check for compile issues, broken imports, stale references, and package mismatches.
+
+5. **Document**
+   - Update README and this file when structure, commands, or scope change.
+   - Remove stale instructions rather than layering new instructions on top.
+
+## Immediate priorities
+
+1. Fix root Gradle correctness.
+2. Confirm root-level build commands.
+3. Eliminate duplicate Android paths.
+4. Remove or quarantine non-Android residue.
+5. Rewrite docs to match the surviving repo.
+
+## Architecture direction
+
+The app is organized into modules:
+- `chimera-core/` for deterministic simulation logic (zero Android deps)
+- `core-*/` for shared infrastructure (database, network, AI adapter, data, UI)
+- `domain/` for use cases
+- `feature-*/` for screen-level modules
+- `app/` for navigation, DI, and entry point
+
+Keep domain logic as framework-light Kotlin where possible.
 
 ## Commands
 
-Run from repository root:
+Run all commands from the repository root:
 
 ```bash
-./gradlew assembleMockDebug      # Debug build with offline-only AI
-./gradlew assembleProdRelease    # Release build with cloud AI
-./gradlew testMockDebugUnitTest  # Run all unit tests
+./gradlew assembleMockDebug      # Debug build (offline AI)
+./gradlew assembleProdRelease    # Release build (cloud AI)
+./gradlew testMockDebugUnitTest  # Unit tests
 ./gradlew :chimera-core:test     # Core engine tests (no Android)
 ./gradlew detekt                 # Static analysis
 ./gradlew clean build            # Full clean build
 ```
 
-Only add more commands to docs after they are verified in the current repo.
+Only document commands that are verified in the current repo.
 
-## Definition of done for cleanup work
+## Cleanup rules
 
-Cleanup is complete only when:
-- The root build path is correct
-- `:app` is the only canonical Android implementation path
-- Stale web/Node/deployment residue is removed or explicitly marked legacy
-- README and CLAUDE instructions match the actual repository
-- A new contributor can build from the root without guessing
+- Do not keep two Android source trees active.
+- Do not keep web or deployment instructions unless they are real and maintained.
+- Do not trust README claims without code support.
+- Do not introduce new scope during cleanup.
+- Preserve buildability after each change.
+
+## Definition of done
+
+A cleanup task is complete only when:
+- The root build path is correct.
+- There is one canonical Android app path.
+- Stale side surfaces are removed or clearly marked legacy.
+- Docs match the actual repo.
+- A new contributor can build the app without guessing.


### PR DESCRIPTION
## Summary

Adopts the user's workflow-focused CLAUDE.md with required loop (Inspect → Plan → Implement → Verify → Document), cleanup rules, and definition of done.

## Verification: User's 5-PR Plan Status

All items from the user's cleanup plan are confirmed complete:

| Plan Item | Status | Evidence |
|---|---|---|
| Fix root build truth | DONE | Kotlin DSL, `alias()` syntax, no Groovy |
| Consolidate app/ vs android/ | DONE | `android/` deleted, `app/` is canonical |
| Remove non-Android residue | DONE | 11 items confirmed removed (netlify, vercel, node_modules, package.json, automation, .vscode, .github/agents, scripts, stale config) |
| Architecture | DONE | 16 modules in settings.gradle.kts, chimera-core is pure Kotlin |
| Rewrite docs | DONE | 0 refs to DialogGPT, consciousness, npm, `cd android` |

The user examined the repo before PRs #76-78 merged. Those PRs addressed every issue they identified. This PR finalizes the CLAUDE.md to their exact workflow specification.

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb