### PR TITLE
SDLC Iter 1: Move MapNode to core-model, fix circular dependency

### DIFF
--- a/core-data/src/main/kotlin/com/chimera/data/MapNodeLoader.kt
+++ b/core-data/src/main/kotlin/com/chimera/data/MapNodeLoader.kt
@@ -1,7 +1,7 @@
 package com.chimera.data
 
 import android.content.Context
-import com.chimera.ui.screens.map.MapNode
+import com.chimera.model.MapNode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/core-data/src/main/kotlin/com/chimera/data/MultiActMapNodeLoader.kt
+++ b/core-data/src/main/kotlin/com/chimera/data/MultiActMapNodeLoader.kt
@@ -3,7 +3,7 @@ package com.chimera.data
 import android.content.Context
 import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.dao.SaveSlotDao
-import com.chimera.ui.screens.map.MapNode
+import com.chimera.model.MapNode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/core-model/src/main/kotlin/com/chimera/model/MapNode.kt
+++ b/core-model/src/main/kotlin/com/chimera/model/MapNode.kt
@@ -1,0 +1,16 @@
+package com.chimera.model
+
+data class MapNode(
+    val id: String,
+    val name: String,
+    val description: String,
+    val isUnlocked: Boolean = false,
+    val isCompleted: Boolean = false,
+    val isRevealed: Boolean = false,
+    val rumorCount: Int = 0,
+    val faction: String? = null,
+    val connectedTo: List<String> = emptyList(),
+    val sceneId: String? = null,
+    val xFraction: Float = 0.5f,
+    val yFraction: Float = 0.5f
+)

--- a/feature-map/src/main/kotlin/com/chimera/feature/map/MapScreen.kt
+++ b/feature-map/src/main/kotlin/com/chimera/feature/map/MapScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chimera.model.MapNode
 import com.chimera.ui.theme.AshBlack
 import com.chimera.ui.theme.DimAsh
 import com.chimera.ui.theme.EmberGold

--- a/feature-map/src/main/kotlin/com/chimera/feature/map/MapViewModel.kt
+++ b/feature-map/src/main/kotlin/com/chimera/feature/map/MapViewModel.kt
@@ -21,20 +21,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
-data class MapNode(
-    val id: String,
-    val name: String,
-    val description: String,
-    val isUnlocked: Boolean = false,
-    val isCompleted: Boolean = false,
-    val isRevealed: Boolean = false,  // fog-of-war: false = hidden (not shown on map)
-    val rumorCount: Int = 0,
-    val faction: String? = null,
-    val connectedTo: List<String> = emptyList(),
-    val sceneId: String? = null,
-    val xFraction: Float = 0.5f,
-    val yFraction: Float = 0.5f
-)
+import com.chimera.model.MapNode
 
 data class MapUiState(
     val nodes: List<MapNode> = emptyList(),


### PR DESCRIPTION
## Summary

SDLC Iteration 1: Fix circular dependency from module reorganization.

**MapNode** was defined in `feature-map` but imported by `core-data` (MapNodeLoader, MultiActMapNodeLoader). core-data cannot depend on feature modules -- this is a circular dependency.

### Fix
- Create `core-model/MapNode.kt` (pure Kotlin data class, no Android deps)
- Remove `MapNode` data class from `feature-map/MapViewModel.kt`
- Update 4 import references across `core-data` and `feature-map`

### Already Fixed (by Copilot in sprint v1.8.0)
- DuelEngine → CombatEngine upgrade with correct `com.chimera.core.engine` import

## Test plan

- [ ] Zero references to `com.chimera.ui.screens.map.MapNode`
- [ ] Zero references to `com.chimera.feature.map.MapNode`
- [ ] `core-data` imports `com.chimera.model.MapNode`
- [ ] `feature-map` imports `com.chimera.model.MapNode`
- [ ] No circular module dependencies

https://claude.ai/code/session_01RCMJswb1Ce6J1UNRbugHHb