### PR TITLE
feat(quest): QuestRepository + domain use cases (A3)

### DIFF
--- a/core-data/src/main/kotlin/com/chimera/data/repository/QuestRepository.kt
+++ b/core-data/src/main/kotlin/com/chimera/data/repository/QuestRepository.kt
@@ -1,0 +1,202 @@
+package com.chimera.data.repository
+
+import com.chimera.database.dao.QuestDao
+import com.chimera.database.dao.QuestObjectiveDao
+import com.chimera.database.entity.QuestEntity
+import com.chimera.database.entity.QuestObjectiveEntity
+import com.chimera.database.mapper.toModel
+import com.chimera.model.ActiveObjectiveSummary
+import com.chimera.model.MapQuestMarker
+import com.chimera.model.ObjectivePrimaryAction
+import com.chimera.model.Quest
+import com.chimera.model.QuestObjective
+import com.chimera.model.QuestObjectiveStatus
+import com.chimera.model.QuestWithObjectives
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class QuestRepository @Inject constructor(
+    private val questDao: QuestDao,
+    private val questObjectiveDao: QuestObjectiveDao
+) {
+
+    /**
+     * Observe all quests for a save slot as domain models with their objectives.
+     */
+    fun observeQuestsWithObjectives(slotId: Long): Flow<List<QuestWithObjectives>> =
+        combine(
+            questDao.observeAll(slotId),
+            questObjectiveDao.observeBySaveSlot(slotId)
+        ) { quests, objectives ->
+            val objMap = objectives.groupBy { it.questId }
+            quests.map { q ->
+                QuestWithObjectives(
+                    quest = q.toModel(),
+                    objectives = objMap[q.id]?.map { it.toModel() } ?: emptyList()
+                )
+            }
+        }
+
+    /**
+     * Observe active quests for a save slot with objectives.
+     */
+    fun observeActiveQuestsWithObjectives(slotId: Long): Flow<List<QuestWithObjectives>> =
+        observeQuestsWithObjectives(slotId).map { list ->
+            list.filter { it.quest.status.name == "ACTIVE" }
+        }
+
+    /**
+     * Summarise the next incomplete objective for each active quest.
+     */
+    fun observeActiveObjectiveSummaries(slotId: Long): Flow<List<ActiveObjectiveSummary>> =
+        combine(
+            questDao.observeActive(slotId),
+            questObjectiveDao.observeBySaveSlot(slotId)
+        ) { quests, objectives ->
+            val objMap = objectives.groupBy { it.questId }
+            quests.mapNotNull { q ->
+                val nextEntity = objMap[q.id]
+                    ?.sortedBy { it.stepIndex }
+                    ?.firstOrNull { (it.status == "ACTIVE" || it.status == "HIDDEN") && it.isRequired }
+                    ?: return@mapNotNull null
+                val action = when (nextEntity.type.uppercase()) {
+                    "VISIT_LOCATION" -> ObjectivePrimaryAction.OPEN_MAP
+                    "SPEAK_TO_NPC" -> ObjectivePrimaryAction.OPEN_MAP
+                    "COMPLETE_SCENE" -> ObjectivePrimaryAction.CONTINUE_SCENE
+                    "VERIFY_RUMOR" -> ObjectivePrimaryAction.VIEW_JOURNAL
+                    else -> ObjectivePrimaryAction.NONE
+                }
+                ActiveObjectiveSummary(
+                    questId = q.id,
+                    objectiveId = nextEntity.id,
+                    title = nextEntity.title,
+                    storyContext = nextEntity.storyContext,
+                    relatedNpcId = nextEntity.targetNpcId,
+                    relatedLocationId = nextEntity.targetMapNodeId,
+                    recentConsequence = nextEntity.recentConsequence,
+                    knownRequirement = nextEntity.knownRequirement,
+                    primaryAction = action
+                )
+            }
+        }
+
+    /**
+     * Observe map markers derived from objectives targeting a specific node.
+     */
+    fun observeMapQuestMarkers(nodeId: String): Flow<List<MapQuestMarker>> =
+        questObjectiveDao.observeActiveByMapNode(nodeId).map { list ->
+            list.map { obj ->
+                MapQuestMarker(
+                    mapNodeId = nodeId,
+                    questId = obj.questId,
+                    objectiveId = obj.id,
+                    title = obj.title,
+                    isActiveTarget = obj.status == "ACTIVE" || obj.status == "HIDDEN",
+                    isLockedTarget = obj.status == "FAILED",
+                    status = try {
+                        QuestObjectiveStatus.valueOf(obj.status.uppercase())
+                    } catch (_: Exception) { QuestObjectiveStatus.ACTIVE }
+                )
+            }
+        }
+
+    /**
+     * Insert a new quest and its objectives atomically.
+     */
+    suspend fun insertQuestWithObjectives(
+        slotId: Long,
+        title: String,
+        description: String,
+        sourceSceneId: String? = null,
+        sourceNpcId: String? = null,
+        objectives: List<QuestObjective> = emptyList()
+    ): Long {
+        val questId = questDao.insert(
+            QuestEntity(
+                saveSlotId = slotId,
+                title = title,
+                description = description,
+                totalSteps = objectives.count { it.isRequired },
+                currentStep = 0,
+                status = "active",
+                sourceSceneId = sourceSceneId,
+                sourceNpcId = sourceNpcId
+            )
+        )
+        val entities = objectives.map {
+            QuestObjectiveEntity(
+                questId = questId,
+                stepIndex = it.stepIndex,
+                type = it.type.name,
+                status = it.status.name,
+                isRequired = it.isRequired,
+                targetSceneId = it.targetSceneId,
+                targetMapNodeId = it.targetMapNodeId,
+                targetNpcId = it.targetNpcId,
+                targetRumorId = it.targetRumorId,
+                targetRecipeId = it.targetRecipeId,
+                targetItemId = it.targetItemId,
+                title = it.title,
+                storyContext = it.storyContext,
+                recentConsequence = it.recentConsequence,
+                knownRequirement = it.knownRequirement,
+                rewardHint = it.rewardHint,
+                riskHint = it.riskHint
+            )
+        }
+        questObjectiveDao.insertAll(entities)
+        return questId
+    }
+
+    /**
+     * Mark an objective as complete by ID.
+     */
+    suspend fun completeObjective(questId: Long, objectiveId: Long) {
+        val now = System.currentTimeMillis()
+        questObjectiveDao.completeById(objectiveId, now)
+        // Advance quest step counter
+        questDao.advanceStep(questId)
+        // Auto-complete quest if the newly-advanced step equals total
+        val quest = questDao.getById(questId)
+        if (quest != null && quest.currentStep + 1 >= quest.totalSteps) {
+            questDao.complete(questId, now)
+        }
+    }
+
+    suspend fun completeObjectiveByScene(questId: Long, sceneId: String) {
+        val now = System.currentTimeMillis()
+        questObjectiveDao.completeMatchingScene(questId, sceneId, now)
+        checkAutoComplete(questId)
+    }
+
+    suspend fun completeObjectiveByNpc(questId: Long, npcId: String) {
+        val now = System.currentTimeMillis()
+        questObjectiveDao.completeMatchingNpc(questId, npcId, now)
+        checkAutoComplete(questId)
+    }
+
+    suspend fun completeObjectiveByMapNode(questId: Long, nodeId: String) {
+        val now = System.currentTimeMillis()
+        questObjectiveDao.completeMatchingNode(questId, nodeId, now)
+        checkAutoComplete(questId)
+    }
+
+    private suspend fun checkAutoComplete(questId: Long) {
+        val quest = questDao.getById(questId) ?: return
+        val now = System.currentTimeMillis()
+        if (quest.currentStep + 1 >= quest.totalSteps) {
+            questDao.complete(questId, now)
+        }
+    }
+
+    /**
+     * Fail a specific objective.
+     */
+    suspend fun failObjective(questId: Long, objectiveId: Long) {
+        questObjectiveDao.failObjective(questId, objectiveId)
+    }
+}

--- a/core-database/src/main/kotlin/com/chimera/database/dao/QuestDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/QuestDao.kt
@@ -29,4 +29,9 @@ interface QuestDao {
 
     @Query("SELECT COUNT(*) FROM quests WHERE save_slot_id = :slotId AND status = 'active'")
     fun observeActiveCount(slotId: Long): Flow<Int>
+    @Query("SELECT * FROM quests WHERE id = :id")
+    suspend fun getById(id: Long): QuestEntity?
+
+    @Query("UPDATE quests SET pinned_order = :order WHERE id = :id")
+    suspend fun pinQuest(id: Long, order: Int?)
 }

--- a/core-database/src/main/kotlin/com/chimera/database/dao/QuestObjectiveDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/QuestObjectiveDao.kt
@@ -48,4 +48,10 @@ interface QuestObjectiveDao {
 
     @Query("SELECT * FROM quest_objectives WHERE target_map_node_id = :nodeId AND status = 'ACTIVE'")
     fun observeActiveByMapNode(nodeId: String): Flow<List<QuestObjectiveEntity>>
+
+    @Query("""SELECT qo.* FROM quest_objectives qo  
+        INNER JOIN quests q ON qo.quest_id = q.id 
+        WHERE q.save_slot_id = :slotId 
+        ORDER BY qo.quest_id, qo.step_index ASC""")
+    fun observeBySaveSlot(slotId: Long): Flow<List<QuestObjectiveEntity>>
 }

--- a/core-database/src/main/kotlin/com/chimera/database/mapper/EntityMappers.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/mapper/EntityMappers.kt
@@ -11,6 +11,13 @@ import com.chimera.model.CharacterRole
 import com.chimera.model.CharacterState
 import com.chimera.model.JournalEntry
 import com.chimera.model.MemoryShard
+import com.chimera.database.entity.QuestEntity
+import com.chimera.database.entity.QuestObjectiveEntity
+import com.chimera.model.Quest
+import com.chimera.model.QuestObjective
+import com.chimera.model.QuestObjectiveStatus
+import com.chimera.model.QuestObjectiveType
+import com.chimera.model.QuestStatus
 import com.chimera.model.SaveSlot
 
 private val converters = Converters()
@@ -125,4 +132,43 @@ fun MemoryShard.toEntity() = MemoryShardEntity(
     tagsJson = converters.fromStringList(tags),
     importanceScore = importanceScore,
     createdAt = createdAt
+)
+
+fun QuestEntity.toModel() = Quest(
+    id = id,
+    saveSlotId = saveSlotId,
+    title = title,
+    description = description,
+    status = try { QuestStatus.valueOf(status.uppercase()) } catch (_: Exception) { QuestStatus.ACTIVE },
+    sourceSceneId = sourceSceneId,
+    sourceNpcId = sourceNpcId,
+    pinnedOrder = pinnedOrder,
+    outcomeText = outcomeText,
+    createdAt = createdAt,
+    completedAt = completedAt,
+    totalSteps = totalSteps,
+    currentStep = currentStep
+)
+
+fun QuestObjectiveEntity.toModel() = QuestObjective(
+    id = id,
+    questId = questId,
+    stepIndex = stepIndex,
+    type = try { QuestObjectiveType.valueOf(type.uppercase().replace(" ", "_")) } catch (_: Exception) { QuestObjectiveType.COMPLETE_SCENE },
+    status = try { QuestObjectiveStatus.valueOf(status.uppercase()) } catch (_: Exception) { QuestObjectiveStatus.ACTIVE },
+    isRequired = isRequired,
+    targetSceneId = targetSceneId,
+    targetMapNodeId = targetMapNodeId,
+    targetNpcId = targetNpcId,
+    targetRumorId = targetRumorId,
+    targetRecipeId = targetRecipeId,
+    targetItemId = targetItemId,
+    title = title,
+    storyContext = storyContext,
+    recentConsequence = recentConsequence,
+    knownRequirement = knownRequirement,
+    rewardHint = rewardHint,
+    riskHint = riskHint,
+    activatedAt = activatedAt,
+    completedAt = completedAt
 )

--- a/core-model/src/main/kotlin/com/chimera/model/Quest.kt
+++ b/core-model/src/main/kotlin/com/chimera/model/Quest.kt
@@ -43,7 +43,9 @@ data class Quest(
     val pinnedOrder: Int? = null,
     val outcomeText: String? = null,
     val createdAt: Long = 0L,
-    val completedAt: Long? = null
+    val completedAt: Long? = null,
+    val totalSteps: Int = 0,
+    val currentStep: Int = 0
 )
 
 data class QuestObjective(

--- a/domain/src/main/kotlin/com/chimera/domain/usecase/CompleteObjectiveUseCase.kt
+++ b/domain/src/main/kotlin/com/chimera/domain/usecase/CompleteObjectiveUseCase.kt
@@ -1,0 +1,27 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.QuestRepository
+import javax.inject.Inject
+
+/**
+ * Complete a quest objective by its scene, NPC, or map node trigger.
+ */
+class CompleteObjectiveUseCase @Inject constructor(
+    private val questRepository: QuestRepository
+) {
+    suspend fun byObjectiveId(questId: Long, objectiveId: Long) {
+        questRepository.completeObjective(questId, objectiveId)
+    }
+
+    suspend fun byScene(questId: Long, sceneId: String) {
+        questRepository.completeObjectiveByScene(questId, sceneId)
+    }
+
+    suspend fun byNpc(questId: Long, npcId: String) {
+        questRepository.completeObjectiveByNpc(questId, npcId)
+    }
+
+    suspend fun byMapNode(questId: Long, nodeId: String) {
+        questRepository.completeObjectiveByMapNode(questId, nodeId)
+    }
+}

--- a/domain/src/main/kotlin/com/chimera/domain/usecase/ObserveActiveObjectiveSummariesUseCase.kt
+++ b/domain/src/main/kotlin/com/chimera/domain/usecase/ObserveActiveObjectiveSummariesUseCase.kt
@@ -1,0 +1,19 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.QuestRepository
+import com.chimera.model.QuestObjective
+import com.chimera.model.QuestObjectiveStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Observe active quests for the current save slot as a flat list of objective summaries.
+ * Used to render the HUD objective panel on Home and other screens.
+ */
+class ObserveActiveObjectiveSummariesUseCase @Inject constructor(
+    private val questRepository: QuestRepository
+) {
+    operator fun invoke(slotId: Long): Flow<List<com.chimera.model.ActiveObjectiveSummary>> =
+        questRepository.observeActiveObjectiveSummaries(slotId)
+}

--- a/domain/src/main/kotlin/com/chimera/domain/usecase/ObserveMapQuestMarkersUseCase.kt
+++ b/domain/src/main/kotlin/com/chimera/domain/usecase/ObserveMapQuestMarkersUseCase.kt
@@ -1,0 +1,17 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.QuestRepository
+import com.chimera.model.MapQuestMarker
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * Observe map quest markers for a specific map node.
+ * Drives the quest indicator overlays on the map screen.
+ */
+class ObserveMapQuestMarkersUseCase @Inject constructor(
+    private val questRepository: QuestRepository
+) {
+    operator fun invoke(nodeId: String): Flow<List<MapQuestMarker>> =
+        questRepository.observeMapQuestMarkers(nodeId)
+}

--- a/domain/src/test/kotlin/com/chimera/domain/usecase/CompleteObjectiveUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/chimera/domain/usecase/CompleteObjectiveUseCaseTest.kt
@@ -1,0 +1,37 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.QuestRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class CompleteObjectiveUseCaseTest {
+
+    private val questRepository: QuestRepository = mock()
+    private fun useCase() = CompleteObjectiveUseCase(questRepository)
+
+    @Test
+    fun `byObjectiveId delegates to repository`() = runTest {
+        useCase().byObjectiveId(1L, 2L)
+        verify(questRepository).completeObjective(1L, 2L)
+    }
+
+    @Test
+    fun `byScene delegates to repository`() = runTest {
+        useCase().byScene(1L, "scene_1")
+        verify(questRepository).completeObjectiveByScene(1L, "scene_1")
+    }
+
+    @Test
+    fun `byNpc delegates to repository`() = runTest {
+        useCase().byNpc(1L, "npc_1")
+        verify(questRepository).completeObjectiveByNpc(1L, "npc_1")
+    }
+
+    @Test
+    fun `byMapNode delegates to repository`() = runTest {
+        useCase().byMapNode(1L, "node_1")
+        verify(questRepository).completeObjectiveByMapNode(1L, "node_1")
+    }
+}

--- a/domain/src/test/kotlin/com/chimera/domain/usecase/ObserveActiveObjectiveSummariesUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/chimera/domain/usecase/ObserveActiveObjectiveSummariesUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.QuestRepository
+import com.chimera.model.ActiveObjectiveSummary
+import com.chimera.model.ObjectivePrimaryAction
+import com.chimera.model.Quest
+import com.chimera.model.QuestStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ObserveActiveObjectiveSummariesUseCaseTest {
+
+    private val questRepository: QuestRepository = mock()
+    private fun useCase() = ObserveActiveObjectiveSummariesUseCase(questRepository)
+
+    @Test
+    fun `invoke emits active objective summaries`() = runTest {
+        // Arrange
+        val summaries = listOf(
+            ActiveObjectiveSummary(
+                questId = 1L,
+                objectiveId = 2L,
+                title = "Reach the watchtower",
+                storyContext = "The watchtower looms ahead",
+                primaryAction = ObjectivePrimaryAction.OPEN_MAP
+            )
+        )
+        whenever(questRepository.observeActiveObjectiveSummaries(1L)).thenReturn(flowOf(summaries))
+
+        // Act
+        val result = useCase()(1L).first()
+
+        // Assert
+        assertEquals(1, result.size)
+        assertEquals("Reach the watchtower", result[0].title)
+        assertEquals(ObjectivePrimaryAction.OPEN_MAP, result[0].primaryAction)
+    }
+
+    @Test
+    fun `invoke emits empty list when no active quests`() = runTest {
+        // Arrange
+        whenever(questRepository.observeActiveObjectiveSummaries(1L)).thenReturn(flowOf(emptyList()))
+
+        // Act
+        val result = useCase()(1L).first()
+
+        // Assert
+        assertTrue(result.isEmpty())
+    }
+}

--- a/domain/src/test/kotlin/com/chimera/domain/usecase/ObserveMapQuestMarkersUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/chimera/domain/usecase/ObserveMapQuestMarkersUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.chimera.domain.usecase
+
+import com.chimera.data.repository.QuestRepository
+import com.chimera.model.MapQuestMarker
+import com.chimera.model.QuestObjectiveStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ObserveMapQuestMarkersUseCaseTest {
+
+    private val questRepository: QuestRepository = mock()
+    private fun useCase() = ObserveMapQuestMarkersUseCase(questRepository)
+
+    @Test
+    fun `invoke emits markers for active node objectives`() = runTest {
+        val markers = listOf(
+            MapQuestMarker(
+                mapNodeId = "forest_1",
+                questId = 1L,
+                objectiveId = 2L,
+                title = "Find the hidden grove",
+                isActiveTarget = true,
+                isLockedTarget = false,
+                status = QuestObjectiveStatus.ACTIVE
+            )
+        )
+        whenever(questRepository.observeMapQuestMarkers("forest_1")).thenReturn(flowOf(markers))
+
+        val result = useCase()("forest_1").first()
+
+        assertEquals(1, result.size)
+        assertEquals("Find the hidden grove", result[0].title)
+        assertTrue(result[0].isActiveTarget)
+    }
+
+    @Test
+    fun `invoke emits empty list when no markers`() = runTest {
+        whenever(questRepository.observeMapQuestMarkers("empty_node")).thenReturn(flowOf(emptyList()))
+
+        val result = useCase()("empty_node").first()
+
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
Implements A3 of the Quest Exploration System — repository layer and domain use cases.

### What's included
- **QuestRepository** (core-data): observe quests/objectives, map markers, insert with objectives, completion triggers, auto-complete check
- **QuestDao** updates: `getById`, `pinQuest` helpers
- **QuestObjectiveDao** updates: `observeBySaveSlot` for slot-scoped reactive joins
- **EntityMappers**: `QuestEntity→Quest`, `QuestObjectiveEntity→QuestObjective`
- **Quest model**: added `totalSteps`, `currentStep` fields
- **Domain use cases**:
  - `ObserveActiveObjectiveSummariesUseCase`
  - `ObserveMapQuestMarkersUseCase`
  - `CompleteObjectiveUseCase`
- **Unit tests** for all 3 use cases (mocked repositories)

### Verification
- `:core-database:compileDebugKotlin` ✅
- `:core-data:compileDebugKotlin` ✅
- `:domain:compileDebugKotlin` ✅

Co-authored-by: Codex <noreply@openai.com>