### PR TITLE
feat(equipment): character equipment system + portrait loadout hashing

### DIFF
--- a/app/src/main/res/drawable/token_aria.xml
+++ b/app/src/main/res/drawable/token_aria.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <!-- Shadow -->
+    <path
+        android:fillColor="#33000000"
+        android:pathData="M24,26m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0" />
+    <!-- Robe body -->
+    <path
+        android:fillColor="#2A2A2E"
+        android:pathData="M24,7C15,7 9,15 11,24C13,35 19,41 24,41C29,41 35,35 37,24C39,15 33,7 24,7Z" />
+    <!-- Hood highlight -->
+    <path
+        android:fillColor="#343438"
+        android:pathData="M24,9C17,9 13,16 14,22C15,28 19,33 24,33C29,33 33,28 34,22C35,16 31,9 24,9Z" />
+    <!-- Arcane band -->
+    <path
+        android:fillColor="#5C7CBA"
+        android:pathData="M13,22h22v3h-22z" />
+    <!-- Gold ring -->
+    <path
+        android:strokeColor="#9E7A1A"
+        android:strokeWidth="1.5"
+        android:pathData="M24,5C13.5,5 5,13.5 5,24s8.5,19 19,19 19,-8.5 19,-19S34.5,5 24,5Z" />
+</vector>

--- a/app/src/main/res/drawable/token_marcus.xml
+++ b/app/src/main/res/drawable/token_marcus.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <!-- Shadow -->
+    <path
+        android:fillColor="#33000000"
+        android:pathData="M24,26m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0" />
+    <!-- Cloak body -->
+    <path
+        android:fillColor="#5C1A1A"
+        android:pathData="M24,8C16,8 10,16 12,24C14,34 20,40 24,40C28,40 34,34 36,24C38,16 32,8 24,8Z" />
+    <!-- Hood highlight -->
+    <path
+        android:fillColor="#8B2A2A"
+        android:pathData="M24,10C18,10 14,16 15,22C16,28 20,32 24,32C28,32 32,28 33,22C34,16 30,10 24,10Z" />
+    <!-- Staff -->
+    <path
+        android:strokeColor="#C89B3C"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M34,12L34,38" />
+    <path
+        android:fillColor="#D4A84E"
+        android:pathData="M32,10h4v4h-4z" />
+    <!-- Gold ring -->
+    <path
+        android:strokeColor="#9E7A1A"
+        android:strokeWidth="1.5"
+        android:pathData="M24,5C13.5,5 5,13.5 5,24s8.5,19 19,19 19,-8.5 19,-19S34.5,5 24,5Z" />
+</vector>

--- a/app/src/main/res/values/token_descriptions.xml
+++ b/app/src/main/res/values/token_descriptions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="token_marcus_description">Token for Marcus, a gothic mage with staff.</string>
+    <string name="token_aria_description">Token for Aria, an arcane scholar.</string>
+</resources>

--- a/core-ai/src/main/kotlin/com/chimera/ai/PortraitGenerationService.kt
+++ b/core-ai/src/main/kotlin/com/chimera/ai/PortraitGenerationService.kt
@@ -19,8 +19,9 @@ import kotlinx.serialization.json.Json
 /**
  * Calls the HuggingFace Inference API to generate a character portrait image.
  *
- * Model: stabilityai/stable-diffusion-xl-base-1.0 (free tier, widely available)
- * Returns raw JPEG bytes, or null on any failure — callers degrade gracefully.
+ * Model: black-forest-labs/FLUX.1-schnell (Apache-2.0, distilled for 1-4 step
+ * inference, live on HF's hf-inference provider). Returns raw JPEG bytes, or
+ * null on any failure — callers degrade gracefully.
  *
  * Adversarial notes:
  * - 503 with estimated_time: model is loading; WorkManager retries handle this
@@ -48,23 +49,42 @@ class PortraitGenerationService(
 
     /**
      * Generates a portrait for the given NPC.
+     * @param equipmentDescriptor Optional gear description (e.g. "a weathered leather
+     *   cloak") appended to the prompt. Null renders the character's base likeness.
      * @return JPEG bytes, or null if token is empty / API fails / model unavailable.
      */
     suspend fun generatePortrait(
         npcName: String,
         npcRole: String,
-        npcTitle: String?
-    ): ByteArray? {
+        npcTitle: String?,
+        equipmentDescriptor: String? = null
+    ): ByteArray? = requestImage(buildPortraitPrompt(npcName, npcRole, npcTitle, equipmentDescriptor))
+
+    /**
+     * Generates a small overhead map-token variant for the given NPC, for use
+     * as a movable marker on the world map (distinct framing from the portrait).
+     * @param equipmentDescriptor Optional gear description, see [generatePortrait].
+     * @return JPEG bytes, or null if token is empty / API fails / model unavailable.
+     */
+    suspend fun generateMapToken(
+        npcName: String,
+        npcRole: String,
+        npcTitle: String?,
+        equipmentDescriptor: String? = null
+    ): ByteArray? = requestImage(buildTokenPrompt(npcName, npcRole, npcTitle, equipmentDescriptor))
+
+    fun close() = client.close()
+
+    private suspend fun requestImage(prompt: String): ByteArray? {
         if (hfToken.isBlank()) return null
 
-        val prompt = buildPrompt(npcName, npcRole, npcTitle)
         return try {
             val response = client.post(
                 "https://api-inference.huggingface.co/models/$modelId"
             ) {
                 header(HttpHeaders.Authorization, "Bearer $hfToken")
                 contentType(ContentType.Application.Json)
-                setBody("""{"inputs":"$prompt","parameters":{"num_inference_steps":20}}""")
+                setBody("""{"inputs":"$prompt","parameters":{"num_inference_steps":4}}""")
             }
             when {
                 response.status.isSuccess()             -> response.body<ByteArray>()
@@ -76,24 +96,62 @@ class PortraitGenerationService(
         }
     }
 
-    fun close() = client.close()
-
-    private fun buildPrompt(name: String, role: String, title: String?): String {
-        val roleHint = when (role.uppercase()) {
-            "COMPANION"  -> "trusted companion, loyal ally"
-            "ANTAGONIST" -> "menacing villain, threatening"
-            "MENTOR"     -> "wise elder, experienced guide"
-            "MERCHANT"   -> "traveling merchant, weathered"
-            "GUARDIAN"   -> "armored guardian, stoic warrior"
-            else         -> "fantasy NPC"
-        }
-        val titlePart = if (!title.isNullOrBlank()) "$title, " else ""
-        return "detailed fantasy RPG portrait of $name, ${titlePart}$roleHint, " +
-               "dark fantasy art, dramatic lighting, highly detailed face, " +
-               "character portrait, professional concept art"
-    }
-
     companion object {
-        const val DEFAULT_MODEL = "stabilityai/stable-diffusion-xl-base-1.0"
+        const val DEFAULT_MODEL = "black-forest-labs/FLUX.1-schnell"
     }
+}
+
+// Pure prompt-building logic, kept free of PortraitGenerationService's HttpClient
+// construction so it can be unit-tested directly without an Android/Ktor engine.
+
+internal fun roleHint(role: String): String = when (role.uppercase()) {
+    "COMPANION"  -> "trusted companion, loyal ally"
+    "ANTAGONIST" -> "menacing villain, threatening"
+    "MENTOR"     -> "wise elder, experienced guide"
+    "MERCHANT"   -> "traveling merchant, weathered"
+    "GUARDIAN"   -> "armored guardian, stoic warrior"
+    "PROTAGONIST" -> "the protagonist, weathered traveler, resolute"
+    else         -> "fantasy NPC"
+}
+
+internal fun buildPortraitPrompt(
+    name: String,
+    role: String,
+    title: String?,
+    equipmentDescriptor: String? = null
+): String {
+    val titlePart = if (!title.isNullOrBlank()) "$title, " else ""
+    val equipmentPart = if (!equipmentDescriptor.isNullOrBlank()) "wearing $equipmentDescriptor, " else ""
+    return "Dark gothic manuscript portrait of $name, ${titlePart}${roleHint(role)}, ${equipmentPart}" +
+           "sumi-e ink wash on aged parchment, visible brush strokes, expressive brushwork, " +
+           "ink bleed edges, monochrome charcoal with restrained accent color, " +
+           "single candlelight from upper left, deep shadows, parchment grain texture, " +
+           "no clean lines, no text, no watermark, isolated portrait, centered upper body, " +
+           "character portrait, game asset sprite"
+}
+
+internal fun buildTokenPrompt(
+    name: String,
+    role: String,
+    title: String?,
+    equipmentDescriptor: String? = null
+): String {
+    val titlePart = if (!title.isNullOrBlank()) "$title, " else ""
+    val equipmentPart = if (!equipmentDescriptor.isNullOrBlank()) "wearing $equipmentDescriptor, " else ""
+    return "Dark gothic ink wash overhead map token of $name, ${titlePart}${roleHint(role)}, ${equipmentPart}" +
+           "small birds-eye view silhouette, top-down perspective, sumi-e ink on aged parchment, " +
+           "visible brush strokes, monochrome charcoal with restrained accent color, " +
+           "centered, compact composition, no clean lines, no text, no watermark, " +
+           "game map marker sprite"
+}
+
+/**
+ * Stable cache-key hash for an equipped loadout (order-independent — sorted item IDs).
+ * "base" is a reserved sentinel meaning no equipment (the character's base likeness),
+ * kept distinct from any real hash so it never collides. Public (unlike the prompt
+ * builders above) because callers outside core-ai need it to compute cache file paths.
+ */
+fun loadoutHash(equippedItemIds: List<String>): String {
+    if (equippedItemIds.isEmpty()) return "base"
+    return equippedItemIds.sorted().joinToString(",").hashCode().toUInt().toString(16)
 }

--- a/core-ai/src/test/kotlin/com/chimera/ai/PortraitGenerationServiceTest.kt
+++ b/core-ai/src/test/kotlin/com/chimera/ai/PortraitGenerationServiceTest.kt
@@ -1,0 +1,81 @@
+package com.chimera.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PortraitGenerationServiceTest {
+
+    @Test fun `portrait prompt uses gothic ink-wash style language`() {
+        val prompt = buildPortraitPrompt("Elara", "COMPANION", null)
+        assertTrue(prompt.contains("gothic"))
+        assertTrue(prompt.contains("sumi-e ink wash"))
+        assertTrue(prompt.contains("Elara"))
+        assertTrue(prompt.contains("trusted companion, loyal ally"))
+    }
+
+    @Test fun `portrait prompt includes title when present`() {
+        val prompt = buildPortraitPrompt("Thorne", "GUARDIAN", "Warden of the Hollow")
+        assertTrue(prompt.contains("Warden of the Hollow,"))
+    }
+
+    @Test fun `portrait prompt omits title when null or blank`() {
+        val withNull = buildPortraitPrompt("Thorne", "GUARDIAN", null)
+        val withBlank = buildPortraitPrompt("Thorne", "GUARDIAN", "  ")
+        assertTrue(!withNull.contains("null"))
+        assertTrue(!withBlank.contains("null"))
+    }
+
+    @Test fun `token prompt uses overhead framing distinct from portrait`() {
+        val tokenPrompt = buildTokenPrompt("Elara", "COMPANION", null)
+        val portraitPrompt = buildPortraitPrompt("Elara", "COMPANION", null)
+        assertTrue(tokenPrompt.contains("overhead map token"))
+        assertTrue(tokenPrompt.contains("birds-eye view"))
+        assertTrue(tokenPrompt.contains("top-down perspective"))
+        assertTrue(tokenPrompt != portraitPrompt)
+    }
+
+    @Test fun `roleHint covers every known role and falls back for unknown roles`() {
+        assertTrue(roleHint("COMPANION").contains("companion"))
+        assertTrue(roleHint("ANTAGONIST").contains("villain"))
+        assertTrue(roleHint("MENTOR").contains("elder"))
+        assertTrue(roleHint("MERCHANT").contains("merchant"))
+        assertTrue(roleHint("GUARDIAN").contains("guardian"))
+        assertTrue(roleHint("PROTAGONIST").contains("protagonist"))
+        assertTrue(roleHint("SOMETHING_UNKNOWN").contains("fantasy NPC"))
+    }
+
+    @Test fun `roleHint is case-insensitive`() {
+        assertTrue(roleHint("companion") == roleHint("COMPANION"))
+    }
+
+    @Test fun `portrait prompt includes equipment descriptor when present`() {
+        val prompt = buildPortraitPrompt("Elara", "COMPANION", null, "a weathered leather cloak")
+        assertTrue(prompt.contains("wearing a weathered leather cloak,"))
+    }
+
+    @Test fun `portrait prompt omits equipment phrasing when descriptor is null or blank`() {
+        val withNull = buildPortraitPrompt("Elara", "COMPANION", null, null)
+        val withBlank = buildPortraitPrompt("Elara", "COMPANION", null, "  ")
+        assertTrue(!withNull.contains("wearing"))
+        assertTrue(!withBlank.contains("wearing"))
+    }
+
+    @Test fun `token prompt includes equipment descriptor when present`() {
+        val prompt = buildTokenPrompt("Elara", "COMPANION", null, "a weathered leather cloak")
+        assertTrue(prompt.contains("wearing a weathered leather cloak,"))
+    }
+
+    @Test fun `loadoutHash is order-independent`() {
+        assertEquals(loadoutHash(listOf("cloak", "boots")), loadoutHash(listOf("boots", "cloak")))
+    }
+
+    @Test fun `loadoutHash differs for different loadouts`() {
+        assertNotEquals(loadoutHash(listOf("cloak")), loadoutHash(listOf("boots")))
+    }
+
+    @Test fun `loadoutHash uses reserved base sentinel for no equipment`() {
+        assertEquals("base", loadoutHash(emptyList()))
+    }
+}

--- a/core-database/schemas/com.chimera.database.ChimeraGameDatabase/10.json
+++ b/core-database/schemas/com.chimera.database.ChimeraGameDatabase/10.json
@@ -1,0 +1,1532 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "50a3397f2caac09af3e39226219a029f",
+    "entities": [
+      {
+        "tableName": "save_slots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `slot_index` INTEGER NOT NULL, `player_name` TEXT NOT NULL, `chapter_tag` TEXT NOT NULL, `playtime_seconds` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `is_empty` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slotIndex",
+            "columnName": "slot_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playerName",
+            "columnName": "player_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterTag",
+            "columnName": "chapter_tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playtimeSeconds",
+            "columnName": "playtime_seconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEmpty",
+            "columnName": "is_empty",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_save_slots_slot_index",
+            "unique": true,
+            "columnNames": [
+              "slot_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_save_slots_slot_index` ON `${TABLE_NAME}` (`slot_index`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "characters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `save_slot_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `title` TEXT, `role` TEXT NOT NULL, `is_player_character` INTEGER NOT NULL, `portrait_res_name` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPlayerCharacter",
+            "columnName": "is_player_character",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "portraitResName",
+            "columnName": "portrait_res_name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_characters_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_characters_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "character_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`character_id` TEXT NOT NULL, `save_slot_id` INTEGER NOT NULL, `health_fraction` REAL NOT NULL, `disposition_to_player` REAL NOT NULL, `emotional_state_json` TEXT NOT NULL, `active_archetype` TEXT, `archetype_variables_json` TEXT NOT NULL, `last_interaction_epoch` INTEGER NOT NULL, PRIMARY KEY(`character_id`), FOREIGN KEY(`character_id`) REFERENCES `characters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthFraction",
+            "columnName": "health_fraction",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dispositionToPlayer",
+            "columnName": "disposition_to_player",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emotionalStateJson",
+            "columnName": "emotional_state_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeArchetype",
+            "columnName": "active_archetype",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "archetypeVariablesJson",
+            "columnName": "archetype_variables_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastInteractionEpoch",
+            "columnName": "last_interaction_epoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "character_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_character_states_character_id",
+            "unique": false,
+            "columnNames": [
+              "character_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_character_states_character_id` ON `${TABLE_NAME}` (`character_id`)"
+          },
+          {
+            "name": "index_character_states_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_character_states_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "characters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "character_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "dialogue_turns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `scene_id` TEXT NOT NULL, `speaker_id` TEXT NOT NULL, `line_text` TEXT NOT NULL, `emotion_json` TEXT NOT NULL, `player_choice_index` INTEGER, `timestamp` INTEGER NOT NULL, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sceneId",
+            "columnName": "scene_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speakerId",
+            "columnName": "speaker_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineText",
+            "columnName": "line_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emotionJson",
+            "columnName": "emotion_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playerChoiceIndex",
+            "columnName": "player_choice_index",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dialogue_turns_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dialogue_turns_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_dialogue_turns_scene_id",
+            "unique": false,
+            "columnNames": [
+              "scene_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dialogue_turns_scene_id` ON `${TABLE_NAME}` (`scene_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "memory_shards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `scene_id` TEXT NOT NULL, `character_id` TEXT NOT NULL, `summary` TEXT NOT NULL, `tags_json` TEXT NOT NULL, `importance_score` REAL NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sceneId",
+            "columnName": "scene_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tags_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "importanceScore",
+            "columnName": "importance_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_memory_shards_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memory_shards_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_memory_shards_character_id",
+            "unique": false,
+            "columnNames": [
+              "character_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memory_shards_character_id` ON `${TABLE_NAME}` (`character_id`)"
+          },
+          {
+            "name": "index_memory_shards_scene_id",
+            "unique": false,
+            "columnNames": [
+              "scene_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memory_shards_scene_id` ON `${TABLE_NAME}` (`scene_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "scene_instances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `scene_id` TEXT NOT NULL, `npc_id` TEXT NOT NULL, `status` TEXT NOT NULL, `turn_count` INTEGER NOT NULL, `used_fallback` INTEGER NOT NULL, `started_at` INTEGER NOT NULL, `completed_at` INTEGER, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sceneId",
+            "columnName": "scene_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "npcId",
+            "columnName": "npc_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "turnCount",
+            "columnName": "turn_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedFallback",
+            "columnName": "used_fallback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_scene_instances_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scene_instances_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_scene_instances_scene_id",
+            "unique": false,
+            "columnNames": [
+              "scene_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scene_instances_scene_id` ON `${TABLE_NAME}` (`scene_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "journal_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `body` TEXT NOT NULL, `category` TEXT NOT NULL, `scene_id` TEXT, `character_id` TEXT, `is_read` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sceneId",
+            "columnName": "scene_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "is_read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_journal_entries_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_journal_entries_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_journal_entries_category",
+            "unique": false,
+            "columnNames": [
+              "category"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_journal_entries_category` ON `${TABLE_NAME}` (`category`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "vows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `description` TEXT NOT NULL, `sworn_to` TEXT, `status` TEXT NOT NULL, `scene_id_origin` TEXT, `created_at` INTEGER NOT NULL, `resolved_at` INTEGER, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "swornTo",
+            "columnName": "sworn_to",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sceneIdOrigin",
+            "columnName": "scene_id_origin",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolvedAt",
+            "columnName": "resolved_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_vows_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vows_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "rumor_packets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `location_id` TEXT NOT NULL, `source_npc` TEXT, `heat_level` REAL NOT NULL, `truth_level` REAL NOT NULL, `sentiment` TEXT NOT NULL, `spread_score` REAL NOT NULL, `is_verified` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationId",
+            "columnName": "location_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceNpc",
+            "columnName": "source_npc",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "heatLevel",
+            "columnName": "heat_level",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "truthLevel",
+            "columnName": "truth_level",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentiment",
+            "columnName": "sentiment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spreadScore",
+            "columnName": "spread_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVerified",
+            "columnName": "is_verified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rumor_packets_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rumor_packets_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_rumor_packets_location_id",
+            "unique": false,
+            "columnNames": [
+              "location_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rumor_packets_location_id` ON `${TABLE_NAME}` (`location_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "faction_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `faction_id` TEXT NOT NULL, `faction_name` TEXT NOT NULL, `influence` REAL NOT NULL, `player_standing` REAL NOT NULL, `controlled_locations_json` TEXT NOT NULL, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "factionId",
+            "columnName": "faction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "factionName",
+            "columnName": "faction_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "influence",
+            "columnName": "influence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playerStanding",
+            "columnName": "player_standing",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "controlledLocationsJson",
+            "columnName": "controlled_locations_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_faction_states_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_faction_states_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_faction_states_save_slot_id_faction_id",
+            "unique": true,
+            "columnNames": [
+              "save_slot_id",
+              "faction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_faction_states_save_slot_id_faction_id` ON `${TABLE_NAME}` (`save_slot_id`, `faction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "quests",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `total_steps` INTEGER NOT NULL, `current_step` INTEGER NOT NULL, `status` TEXT NOT NULL, `source_scene_id` TEXT, `source_npc_id` TEXT, `pinned_order` INTEGER, `outcome_text` TEXT, `created_at` INTEGER NOT NULL, `completed_at` INTEGER, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSteps",
+            "columnName": "total_steps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStep",
+            "columnName": "current_step",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceSceneId",
+            "columnName": "source_scene_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourceNpcId",
+            "columnName": "source_npc_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinnedOrder",
+            "columnName": "pinned_order",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outcomeText",
+            "columnName": "outcome_text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_quests_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quests_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "quest_objectives",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `quest_id` INTEGER NOT NULL, `step_index` INTEGER NOT NULL, `type` TEXT NOT NULL, `status` TEXT NOT NULL, `is_required` INTEGER NOT NULL, `target_scene_id` TEXT, `target_map_node_id` TEXT, `target_npc_id` TEXT, `target_rumor_id` INTEGER, `target_recipe_id` TEXT, `target_item_id` TEXT, `title` TEXT NOT NULL, `story_context` TEXT NOT NULL, `recent_consequence` TEXT, `known_requirement` TEXT, `reward_hint` TEXT, `risk_hint` TEXT, `created_at` INTEGER NOT NULL, `activated_at` INTEGER, `completed_at` INTEGER, FOREIGN KEY(`quest_id`) REFERENCES `quests`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "questId",
+            "columnName": "quest_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepIndex",
+            "columnName": "step_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRequired",
+            "columnName": "is_required",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSceneId",
+            "columnName": "target_scene_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetMapNodeId",
+            "columnName": "target_map_node_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetNpcId",
+            "columnName": "target_npc_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetRumorId",
+            "columnName": "target_rumor_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetRecipeId",
+            "columnName": "target_recipe_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetItemId",
+            "columnName": "target_item_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storyContext",
+            "columnName": "story_context",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recentConsequence",
+            "columnName": "recent_consequence",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "knownRequirement",
+            "columnName": "known_requirement",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rewardHint",
+            "columnName": "reward_hint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "riskHint",
+            "columnName": "risk_hint",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activatedAt",
+            "columnName": "activated_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_quest_objectives_quest_id",
+            "unique": false,
+            "columnNames": [
+              "quest_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quest_objectives_quest_id` ON `${TABLE_NAME}` (`quest_id`)"
+          },
+          {
+            "name": "index_quest_objectives_target_scene_id",
+            "unique": false,
+            "columnNames": [
+              "target_scene_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quest_objectives_target_scene_id` ON `${TABLE_NAME}` (`target_scene_id`)"
+          },
+          {
+            "name": "index_quest_objectives_target_map_node_id",
+            "unique": false,
+            "columnNames": [
+              "target_map_node_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quest_objectives_target_map_node_id` ON `${TABLE_NAME}` (`target_map_node_id`)"
+          },
+          {
+            "name": "index_quest_objectives_target_npc_id",
+            "unique": false,
+            "columnNames": [
+              "target_npc_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_quest_objectives_target_npc_id` ON `${TABLE_NAME}` (`target_npc_id`)"
+          },
+          {
+            "name": "index_quest_objectives_quest_id_step_index",
+            "unique": true,
+            "columnNames": [
+              "quest_id",
+              "step_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_quest_objectives_quest_id_step_index` ON `${TABLE_NAME}` (`quest_id`, `step_index`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "quests",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "quest_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inventory_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `item_id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `category` TEXT NOT NULL, `quantity` INTEGER NOT NULL, `rarity` TEXT NOT NULL, `source_scene_id` TEXT, `acquired_at` INTEGER NOT NULL, `equip_slot` TEXT, FOREIGN KEY(`save_slot_id`) REFERENCES `save_slots`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rarity",
+            "columnName": "rarity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceSceneId",
+            "columnName": "source_scene_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "acquiredAt",
+            "columnName": "acquired_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipSlot",
+            "columnName": "equip_slot",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_inventory_items_save_slot_id",
+            "unique": false,
+            "columnNames": [
+              "save_slot_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_inventory_items_save_slot_id` ON `${TABLE_NAME}` (`save_slot_id`)"
+          },
+          {
+            "name": "index_inventory_items_save_slot_id_item_id",
+            "unique": true,
+            "columnNames": [
+              "save_slot_id",
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_inventory_items_save_slot_id_item_id` ON `${TABLE_NAME}` (`save_slot_id`, `item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "save_slots",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "save_slot_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "crafting_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `result_item_id` TEXT NOT NULL, `result_name` TEXT NOT NULL, `result_category` TEXT NOT NULL, `result_rarity` TEXT NOT NULL, `ingredients_json` TEXT NOT NULL, `required_scene` TEXT, `required_npc` TEXT, `is_discovered` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resultItemId",
+            "columnName": "result_item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resultName",
+            "columnName": "result_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resultCategory",
+            "columnName": "result_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resultRarity",
+            "columnName": "result_rarity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredients_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiredScene",
+            "columnName": "required_scene",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requiredNpc",
+            "columnName": "required_npc",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isDiscovered",
+            "columnName": "is_discovered",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "character_equipment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `save_slot_id` INTEGER NOT NULL, `character_id` TEXT NOT NULL, `equip_slot` TEXT NOT NULL, `item_id` TEXT NOT NULL, `equipped_at` INTEGER NOT NULL, FOREIGN KEY(`character_id`) REFERENCES `characters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saveSlotId",
+            "columnName": "save_slot_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipSlot",
+            "columnName": "equip_slot",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equippedAt",
+            "columnName": "equipped_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_character_equipment_character_id",
+            "unique": false,
+            "columnNames": [
+              "character_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_character_equipment_character_id` ON `${TABLE_NAME}` (`character_id`)"
+          },
+          {
+            "name": "index_character_equipment_character_id_equip_slot",
+            "unique": true,
+            "columnNames": [
+              "character_id",
+              "equip_slot"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_character_equipment_character_id_equip_slot` ON `${TABLE_NAME}` (`character_id`, `equip_slot`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "characters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "character_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '50a3397f2caac09af3e39226219a029f')"
+    ]
+  }
+}

--- a/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/ChimeraGameDatabase.kt
@@ -10,6 +10,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.chimera.database.converter.Converters
 import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterEquipmentDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.CraftingRecipeDao
 import com.chimera.database.dao.DialogueTurnDao
@@ -24,6 +25,7 @@ import com.chimera.database.dao.SaveSlotDao
 import com.chimera.database.dao.SceneInstanceDao
 import com.chimera.database.dao.VowDao
 import com.chimera.database.entity.CharacterEntity
+import com.chimera.database.entity.CharacterEquipmentEntity
 import com.chimera.database.entity.CharacterStateEntity
 import com.chimera.database.entity.CraftingRecipeEntity
 import com.chimera.database.entity.DialogueTurnEntity
@@ -53,9 +55,10 @@ import com.chimera.database.entity.VowEntity
         QuestEntity::class,
         QuestObjectiveEntity::class,
         InventoryItemEntity::class,
-        CraftingRecipeEntity::class
+        CraftingRecipeEntity::class,
+        CharacterEquipmentEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -75,6 +78,7 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
     abstract fun craftingRecipeDao(): CraftingRecipeDao
     abstract fun rumorPacketDao(): RumorPacketDao
     abstract fun factionStateDao(): FactionStateDao
+    abstract fun characterEquipmentDao(): CharacterEquipmentDao
 
     companion object {
         const val DATABASE_NAME = "chimera_game.db"
@@ -86,7 +90,7 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
                 DATABASE_NAME
             )
                 .addCallback(PrepopulateCallback())
-                .addMigrations(MIGRATION_7_8, MIGRATION_8_9)
+                .addMigrations(MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
             if (BuildConfig.DEBUG) builder.fallbackToDestructiveMigration()
             return builder.build()
         }
@@ -151,6 +155,29 @@ abstract class ChimeraGameDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_quest_objectives_target_map_node_id ON quest_objectives(target_map_node_id)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_quest_objectives_target_npc_id ON quest_objectives(target_npc_id)")
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_quest_objectives_quest_step ON quest_objectives(quest_id, step_index)")
+            }
+        }
+
+        /**
+         * 9 → 10: Add equip_slot to inventory_items and a character_equipment join table.
+         * Additive only — no existing tables/columns are modified.
+         */
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE inventory_items ADD COLUMN equip_slot TEXT DEFAULT NULL")
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS character_equipment (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        save_slot_id INTEGER NOT NULL,
+                        character_id TEXT NOT NULL,
+                        equip_slot TEXT NOT NULL,
+                        item_id TEXT NOT NULL,
+                        equipped_at INTEGER NOT NULL,
+                        FOREIGN KEY(character_id) REFERENCES characters(id) ON DELETE CASCADE
+                    )
+                """.trimIndent())
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_character_equipment_character_id ON character_equipment(character_id)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_character_equipment_character_id_equip_slot ON character_equipment(character_id, equip_slot)")
             }
         }
     }

--- a/core-database/src/main/kotlin/com/chimera/database/dao/CharacterDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/CharacterDao.kt
@@ -28,6 +28,9 @@ interface CharacterDao {
     @Query("SELECT * FROM characters WHERE save_slot_id = :slotId AND is_player_character = 1 LIMIT 1")
     suspend fun getPlayerCharacter(slotId: Long): CharacterEntity?
 
+    @Query("SELECT * FROM characters WHERE save_slot_id = :slotId AND is_player_character = 1 LIMIT 1")
+    fun observePlayerCharacter(slotId: Long): Flow<CharacterEntity?>
+
     @Query("SELECT * FROM characters WHERE save_slot_id = :slotId AND role = 'COMPANION'")
     fun observeCompanions(slotId: Long): Flow<List<CharacterEntity>>
 

--- a/core-database/src/main/kotlin/com/chimera/database/dao/CharacterEquipmentDao.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/dao/CharacterEquipmentDao.kt
@@ -1,0 +1,24 @@
+package com.chimera.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.chimera.database.entity.CharacterEquipmentEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CharacterEquipmentDao {
+
+    @Query("SELECT * FROM character_equipment WHERE character_id = :characterId")
+    fun observeByCharacter(characterId: String): Flow<List<CharacterEquipmentEntity>>
+
+    @Query("SELECT * FROM character_equipment WHERE character_id = :characterId")
+    suspend fun getByCharacter(characterId: String): List<CharacterEquipmentEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(equipment: CharacterEquipmentEntity)
+
+    @Query("DELETE FROM character_equipment WHERE character_id = :characterId AND equip_slot = :equipSlot")
+    suspend fun unequip(characterId: String, equipSlot: String)
+}

--- a/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.chimera.database.di
 import android.content.Context
 import com.chimera.database.ChimeraGameDatabase
 import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterEquipmentDao
 import com.chimera.database.dao.CharacterStateDao
 import com.chimera.database.dao.CraftingRecipeDao
 import com.chimera.database.dao.DialogueTurnDao
@@ -47,4 +48,5 @@ object DatabaseModule {
     @Provides fun provideQuestObjectiveDao(db: ChimeraGameDatabase): QuestObjectiveDao = db.questObjectiveDao()
     @Provides fun provideInventoryDao(db: ChimeraGameDatabase): InventoryDao = db.inventoryDao()
     @Provides fun provideCraftingRecipeDao(db: ChimeraGameDatabase): CraftingRecipeDao = db.craftingRecipeDao()
+    @Provides fun provideCharacterEquipmentDao(db: ChimeraGameDatabase): CharacterEquipmentDao = db.characterEquipmentDao()
 }

--- a/core-database/src/main/kotlin/com/chimera/database/entity/CharacterEquipmentEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/CharacterEquipmentEntity.kt
@@ -1,0 +1,39 @@
+package com.chimera.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "character_equipment",
+    foreignKeys = [
+        ForeignKey(
+            entity = CharacterEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["character_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("character_id"), Index(value = ["character_id", "equip_slot"], unique = true)]
+)
+data class CharacterEquipmentEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "save_slot_id")
+    val saveSlotId: Long,
+
+    @ColumnInfo(name = "character_id")
+    val characterId: String,
+
+    @ColumnInfo(name = "equip_slot")
+    val equipSlot: String,
+
+    @ColumnInfo(name = "item_id")
+    val itemId: String,
+
+    @ColumnInfo(name = "equipped_at")
+    val equippedAt: Long = System.currentTimeMillis()
+)

--- a/core-database/src/main/kotlin/com/chimera/database/entity/InventoryItemEntity.kt
+++ b/core-database/src/main/kotlin/com/chimera/database/entity/InventoryItemEntity.kt
@@ -42,5 +42,8 @@ data class InventoryItemEntity(
     val sourceSceneId: String? = null,
 
     @ColumnInfo(name = "acquired_at")
-    val acquiredAt: Long = System.currentTimeMillis()
+    val acquiredAt: Long = System.currentTimeMillis(),
+
+    @ColumnInfo(name = "equip_slot")
+    val equipSlot: String? = null // null = not equippable; e.g. "OUTFIT"
 )

--- a/feature-camp/build.gradle.kts
+++ b/feature-camp/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":core-ui"))
     implementation(project(":core-database"))
     implementation(project(":core-data"))
+    implementation(project(":core-ai"))
     implementation(project(":domain"))
 
     implementation(platform(libs.compose.bom))

--- a/feature-camp/src/main/kotlin/com/chimera/feature/camp/InventoryViewModel.kt
+++ b/feature-camp/src/main/kotlin/com/chimera/feature/camp/InventoryViewModel.kt
@@ -1,11 +1,19 @@
 package com.chimera.feature.camp
 
+import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chimera.ai.PortraitGenerationService
+import com.chimera.ai.loadoutHash
 import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterEquipmentDao
 import com.chimera.database.dao.InventoryDao
+import com.chimera.database.entity.CharacterEquipmentEntity
 import com.chimera.database.entity.InventoryItemEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -14,6 +22,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
 enum class InventoryCategory(val label: String, val dbKey: String?) {
@@ -28,13 +38,19 @@ data class InventoryUiState(
     val items: List<InventoryItemEntity> = emptyList(),
     val selectedCategory: InventoryCategory = InventoryCategory.ALL,
     val totalCount: Int = 0,
-    val isLoading: Boolean = true
+    val isLoading: Boolean = true,
+    val playerCharacterId: String? = null,
+    val equippedItemIds: Set<String> = emptySet()
 )
 
 @HiltViewModel
 class InventoryViewModel @Inject constructor(
     private val inventoryDao: InventoryDao,
-    private val gameSessionManager: GameSessionManager
+    private val characterDao: CharacterDao,
+    private val characterEquipmentDao: CharacterEquipmentDao,
+    private val portraitService: PortraitGenerationService,
+    private val gameSessionManager: GameSessionManager,
+    @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
     private val _selectedCategory = MutableStateFlow(InventoryCategory.ALL)
@@ -43,26 +59,105 @@ class InventoryViewModel @Inject constructor(
     val uiState: StateFlow<InventoryUiState> = gameSessionManager.activeSlotId
         .flatMapLatest { slotId ->
             if (slotId == null) return@flatMapLatest flowOf(InventoryUiState(isLoading = false))
-            combine(
-                inventoryDao.observeAll(slotId),
-                inventoryDao.observeItemCount(slotId),
-                _selectedCategory
-            ) { allItems, totalCount, category ->
-                val filtered = when (category) {
-                    InventoryCategory.ALL -> allItems
-                    else -> allItems.filter { it.category == category.dbKey }
+            characterDao.observePlayerCharacter(slotId).flatMapLatest { playerCharacter ->
+                val equippedFlow = playerCharacter?.let { characterEquipmentDao.observeByCharacter(it.id) }
+                    ?: flowOf(emptyList())
+                combine(
+                    inventoryDao.observeAll(slotId),
+                    inventoryDao.observeItemCount(slotId),
+                    _selectedCategory,
+                    equippedFlow
+                ) { allItems, totalCount, category, equipped ->
+                    val filtered = when (category) {
+                        InventoryCategory.ALL -> allItems
+                        else -> allItems.filter { it.category == category.dbKey }
+                    }
+                    InventoryUiState(
+                        items = filtered,
+                        selectedCategory = category,
+                        totalCount = totalCount,
+                        isLoading = false,
+                        playerCharacterId = playerCharacter?.id,
+                        equippedItemIds = equipped.map { it.itemId }.toSet()
+                    )
                 }
-                InventoryUiState(
-                    items = filtered,
-                    selectedCategory = category,
-                    totalCount = totalCount,
-                    isLoading = false
-                )
             }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), InventoryUiState())
 
     fun selectCategory(category: InventoryCategory) {
         _selectedCategory.value = category
+    }
+
+    /** Equips [item] into its equipSlot for the player, replacing anything already there. */
+    fun equipItem(item: InventoryItemEntity) {
+        val equipSlot = item.equipSlot ?: return
+        val slotId = gameSessionManager.activeSlotId.value ?: return
+        val playerCharacterId = uiState.value.playerCharacterId ?: return
+        viewModelScope.launch {
+            characterEquipmentDao.upsert(
+                CharacterEquipmentEntity(
+                    saveSlotId = slotId,
+                    characterId = playerCharacterId,
+                    equipSlot = equipSlot,
+                    itemId = item.itemId
+                )
+            )
+            refreshPortraitForLoadout(playerCharacterId)
+        }
+    }
+
+    fun unequipItem(equipSlot: String) {
+        val playerCharacterId = uiState.value.playerCharacterId ?: return
+        viewModelScope.launch {
+            characterEquipmentDao.unequip(playerCharacterId, equipSlot)
+            refreshPortraitForLoadout(playerCharacterId)
+        }
+    }
+
+    /**
+     * Regenerates the player's portrait to reflect their current loadout — on-demand
+     * only, never eager. Cached forever per distinct loadout by [loadoutHash], so a
+     * previously-worn combination costs zero further HF calls. Unequipping back to
+     * "base" (no gear) is always free: it re-points portraitResName at the original
+     * portrait NpcPortraitSyncWorker already generated, no HF call needed.
+     */
+    private suspend fun refreshPortraitForLoadout(characterId: String) {
+        val character = characterDao.getById(characterId) ?: return
+        val equipped = characterEquipmentDao.getByCharacter(characterId)
+        val hash = loadoutHash(equipped.map { it.itemId })
+
+        val portraitDir = File(appContext.filesDir, "portraits").apply { mkdirs() }
+        val file = if (hash == "base") {
+            File(portraitDir, "npc_$characterId.jpg")
+        } else {
+            File(portraitDir, "npc_${characterId}_$hash.jpg")
+        }
+
+        if (file.exists()) {
+            if (character.portraitResName != file.absolutePath) {
+                characterDao.updatePortraitResName(characterId, file.absolutePath)
+            }
+            return
+        }
+
+        val equipmentDescriptor = equipped.firstNotNullOfOrNull { eq ->
+            inventoryDao.getByItemId(character.saveSlotId, eq.itemId)?.name
+        }
+
+        try {
+            val bytes = portraitService.generatePortrait(
+                npcName = character.name,
+                npcRole = character.role,
+                npcTitle = character.title,
+                equipmentDescriptor = equipmentDescriptor
+            )
+            if (bytes != null) {
+                file.writeBytes(bytes)
+                characterDao.updatePortraitResName(characterId, file.absolutePath)
+            }
+        } catch (e: Exception) {
+            Log.e("InventoryViewModel", "Failed to regenerate portrait for loadout: ${e.message}")
+        }
     }
 }

--- a/feature-camp/src/test/kotlin/com/chimera/feature/camp/InventoryViewModelTest.kt
+++ b/feature-camp/src/test/kotlin/com/chimera/feature/camp/InventoryViewModelTest.kt
@@ -1,8 +1,13 @@
 package com.chimera.feature.camp
 
+import android.content.Context
 import app.cash.turbine.test
+import com.chimera.ai.PortraitGenerationService
 import com.chimera.data.GameSessionManager
+import com.chimera.database.dao.CharacterDao
+import com.chimera.database.dao.CharacterEquipmentDao
 import com.chimera.database.dao.InventoryDao
+import com.chimera.database.entity.CharacterEntity
 import com.chimera.database.entity.InventoryItemEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,6 +24,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -28,9 +34,14 @@ class InventoryViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private val inventoryDao: InventoryDao = mock()
+    private val characterDao: CharacterDao = mock()
+    private val characterEquipmentDao: CharacterEquipmentDao = mock()
+    private val portraitService: PortraitGenerationService = mock()
     private val gameSessionManager: GameSessionManager = mock()
+    private val appContext: Context = mock()
 
     private val slotId = 1L
+    private val playerCharacterId = "player_1"
 
     // Reusable test items
     private val artifact = InventoryItemEntity(
@@ -69,6 +80,15 @@ class InventoryViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        val player = CharacterEntity(
+            id = playerCharacterId,
+            saveSlotId = slotId,
+            name = "Test Player",
+            role = "PROTAGONIST",
+            isPlayerCharacter = true
+        )
+        whenever(characterDao.observePlayerCharacter(slotId)).thenReturn(flowOf(player))
+        whenever(characterEquipmentDao.observeByCharacter(playerCharacterId)).thenReturn(flowOf(emptyList()))
     }
 
     @After
@@ -78,7 +98,11 @@ class InventoryViewModelTest {
 
     private fun buildViewModel(): InventoryViewModel = InventoryViewModel(
         inventoryDao = inventoryDao,
-        gameSessionManager = gameSessionManager
+        characterDao = characterDao,
+        characterEquipmentDao = characterEquipmentDao,
+        portraitService = portraitService,
+        gameSessionManager = gameSessionManager,
+        appContext = appContext
     )
 
     // ─── Slot null: no active game ───────────────────────────────────────────


### PR DESCRIPTION
- Add CharacterEquipmentEntity/DAO and DB migration 9→10.
- Add equip_slot to InventoryItemEntity.
- Add CharacterDao.observePlayerCharacter.
- Upgrade PortraitGenerationService to FLUX.1-schnell; add generateMapToken,
  optional equipmentDescriptor, and stable loadoutHash.
- Wire equip/unequip into InventoryViewModel with on-demand portrait
  regeneration per loadout.
- Add token drawable/description assets for Aria and Marcus.
- Add unit tests for PortraitGenerationService prompt builders and loadoutHash.

Co-authored-by: Qwen-Coder <qwen-coder@alibabacloud.com>
